### PR TITLE
compose: make usage of xkbcompose optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ CFLAGS += -std=c99
 CFLAGS += -pipe
 CFLAGS += -Wall
 CPPFLAGS += -D_GNU_SOURCE
+CPPFLAGS += -DXKBCOMPOSE=$(shell if test -e /usr/include/xkbcommon/xkbcommon-compose.h ; then echo 1 ; else echo 0 ; fi )
 CFLAGS += $(shell $(PKG_CONFIG) --cflags cairo xcb-dpms xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
 LIBS += $(shell $(PKG_CONFIG) --libs cairo xcb-dpms xcb-xinerama xcb-atom xcb-image xcb-xkb xkbcommon xkbcommon-x11)
 LIBS += -lpam


### PR DESCRIPTION
Older versions of libxkbcommon-dev (in Debian / Ubuntu) don't provide
xkbcommon-compose.h and the accompanying API.  Detect whether the header
file is present when building and if not, revert to the behaviour prior to
ef3ef30400150f015695df08780e589c6407e646, the commit that introduced the
usage of that header.

Signed-off-by: Joe MacDonald joe_macdonald@mentor.com
