### PR TITLE
fix destdir prefix for mandir..

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ clean:
 install: all
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) -d $(DESTDIR)$(SYSCONFDIR)/pam.d
+	$(INSTALL) -d $(DESTDIR)$(MANDIR)/man1
 	$(INSTALL) -m 755 i3lock $(DESTDIR)$(PREFIX)/bin/i3lock
 	$(INSTALL) -m 644 i3lock.pam $(DESTDIR)$(SYSCONFDIR)/pam.d/i3lock
 	gzip -kf i3lock.1

--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ install: all
 	$(INSTALL) -m 755 i3lock $(DESTDIR)$(PREFIX)/bin/i3lock
 	$(INSTALL) -m 644 i3lock.pam $(DESTDIR)$(SYSCONFDIR)/pam.d/i3lock
 	gzip -kf i3lock.1
-	$(INSTALL) -m 644 i3lock.1.gz $(MANDIR)/man1/i3lock.1.gz
+	$(INSTALL) -m 644 i3lock.1.gz $(DESTDIR)$(MANDIR)/man1/i3lock.1.gz
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/i3lock
-	rm -f $(MANDIR)/man1/i3lock.1.gz
+	rm -f $(DESTDIR)$(MANDIR)/man1/i3lock.1.gz
 
 dist: clean
 	[ ! -d i3lock-${VERSION} ] || rm -rf i3lock-${VERSION}


### PR DESCRIPTION
need this fix to prevent sandbox errors in gentoo..
