### PR TITLE
Add missing dependency to apt-get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Requirements
 
 ##### Ubuntu
 
-    sudo apt-get install pkg-config libxcb1 libpam-dev libcairo-dev libxcb-xinerama0-dev libev-dev libx11-dev libx11-xcb-dev libxkbcommon0 libxkbcommon-x11-0 libxcb-dpms0-dev libxcb-image0-dev libxcb-util0-dev libxcb-xkb-dev libxkbcommon-x11-dev
+    sudo apt-get install pkg-config libxcb1 libpam-dev libcairo-dev libxcb-xinerama0-dev libev-dev libx11-dev libx11-xcb-dev libxkbcommon0 libxkbcommon-x11-0 libxcb-dpms0-dev libxcb-image0-dev libxcb-util0-dev libxcb-xkb-dev libxkbcommon-x11-dev libxkbcommon-dev
     
 ##### Aur Package
 https://aur.archlinux.org/packages/i3lock-color-git


### PR DESCRIPTION
After running the apt-get command from the README.md I still had a missing xkbcommon/xkbcommon.h, so I've added the missing package.