### PR TITLE
Added support for setting status font

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Many little improvements have been made to i3lock over time:
 		    - **NOTE**: This can potentially allow sensitive information to display over the screen locker, so take care when you use this option.
      - `-B=sigma, --blur` -- enables Gaussian blur. Sigma is the blur radius.
 	      - Note: You can still composite images over the blur (but still under the indicator) with -i.
-				- Eventually there might be an `imagepos` arg, similar to `time` and `datepos`. 
+				- Eventually there might be an `imagepos` arg, similar to `time` and `datepos`.
      - `--indpos="x+(w/2):y+(h/2)"` -- position of the unlock indicator. Expressions using the variables x (current screen's x value), y (current screen's y value), w (screen width), h (screen height), and r (indicator radius) can be used.
      - `--timestr="%H:%M:%S"` -- allows custom overriding of the time format string. Accepts `strftime` formatting. Default is `"%H:%M:%S"`.
      - `--timepos="ix:iy-20"` -- position of the time. All the variables in `indpos` can be used here, as well as the additional values ix (indicator x position), iy (indicator y position), cw (clock width), and ch (clock height).
@@ -52,12 +52,13 @@ Many little improvements have been made to i3lock over time:
      - `--datecolor=rrggbbaa` -- color of the date string
      - `--datefont="sans-serif"` -- font used for the date display
      - `--datesize=14` -- font size for the date display
-		 - `--veriftext="verifying…"` -- text to be shown while verifying
-		 - `--wrongtext="wrong!"` -- text to be shown upon an incorrect password being entered
-		 - `--textsize=28` -- font size for the status text
-		 - `--modsize=14` -- font size for the modifier keys listing
-		 - `--radius=90` -- the radius of the circle indicator
-		 - `--ring-width=7` -- the width of the indicator ring
+     - `--veriftext="verifying…"` -- text to be shown while verifying
+     - `--wrongtext="wrong!"` -- text to be shown upon an incorrect password being entered
+     - `--statusfont="sans-serif"` -- font used for the status text
+     - `--textsize=28` -- font size for the status text
+     - `--modsize=14` -- font size for the modifier keys listing
+     - `--radius=90` -- the radius of the circle indicator
+     - `--ring-width=7` -- the width of the indicator ring
 
 - You can specify whether i3lock should bell upon a wrong password.
 
@@ -93,7 +94,7 @@ If you don't understand what makefiles are and how they work, start reading [her
 ##### Ubuntu
 
     sudo apt-get install pkg-config libxcb1 libpam-dev libcairo-dev libxcb-composite0 libxcb-composite0-dev libxcb-xinerama0-dev libev-dev libx11-dev libx11-xcb-dev libxkbcommon0 libxkbcommon-x11-0 libxcb-dpms0-dev libxcb-image0-dev libxcb-util0-dev libxcb-xkb-dev libxkbcommon-x11-dev libxkbcommon-dev
-    
+
 ##### Aur Package
 Stable:
 https://aur.archlinux.org/packages/i3lock-color/

--- a/i3lock.c
+++ b/i3lock.c
@@ -87,7 +87,7 @@ bool always_show_clock = false;
 bool show_indicator = false;
 float refresh_rate = 1.0;
 
-/* there's some issues with compositing - upstream removed support for this, but we'll allow people to supply an arg to enable it */ 
+/* there's some issues with compositing - upstream removed support for this, but we'll allow people to supply an arg to enable it */
 bool composite = false;
 /* time formatter strings for date/time
     I picked 32-length char arrays because some people might want really funky time formatters.
@@ -106,6 +106,7 @@ char time_format[32] = "%H:%M:%S\0";
 char date_format[32] = "%A, %m %Y\0";
 char time_font[32] = "sans-serif\0";
 char date_font[32] = "sans-serif\0";
+char status_font[32] = "sans-serif\0";
 char layout_font[32] = "sans-serif\0";
 char ind_x_expr[32] = "x + (w / 2)\0";
 char ind_y_expr[32] = "y + (h / 2)\0";
@@ -219,7 +220,7 @@ char* get_keylayoutname(int mode) {
     if(XkbGetState(display, XkbUseCoreKbd, &state) != Success) {
         DEBUG("Error getting keyboard state");
         return NULL;
-    }	
+    }
 
     answer = XGetAtomName(display, keyboard->names->groups[state.group]);
     DEBUG("keylayout answer is: [%s]\n", answer);
@@ -256,7 +257,7 @@ char* get_keylayoutname(int mode) {
             break;
     }
     DEBUG("answer after mode parsing: [%s]\n", answer);
-	// Free symbolic names structures 
+	// Free symbolic names structures
 	XkbFreeNames(keyboard, XkbGroupNamesMask, True);
     // note: this is called in option parsing, so this debug() may not trigger unless --debug is the first option
     return answer;
@@ -1012,14 +1013,14 @@ int main(int argc, char *argv[]) {
         {"linecolor", required_argument, NULL, 0},        // --l-c
         {"textcolor", required_argument, NULL, 0},        // --t-c
         {"layoutcolor", required_argument, NULL, 0},        // --t-c
-        {"timecolor", required_argument, NULL, 0},       
-        {"datecolor", required_argument, NULL, 0},       
+        {"timecolor", required_argument, NULL, 0},
+        {"datecolor", required_argument, NULL, 0},
         {"keyhlcolor", required_argument, NULL, 0},       // --k-c
         {"bshlcolor", required_argument, NULL, 0},        // --b-c
         {"separatorcolor", required_argument, NULL, 0},
         {"line-uses-ring", no_argument, NULL, 'r'},
         {"line-uses-inside", no_argument, NULL, 's'},
-        /* s for in_s_ide; ideally I'd use -I but that's used for timeout, which should use -T, but compatibility argh 
+        /* s for in_s_ide; ideally I'd use -I but that's used for timeout, which should use -T, but compatibility argh
          * note: `I` has been deprecated for a while, so I might just remove that and reshuffle that? */
         {"screen", required_argument, NULL, 'S'},
         {"blur", required_argument, NULL, 'B'},
@@ -1028,7 +1029,7 @@ int main(int argc, char *argv[]) {
         {"indicator", no_argument, NULL, 0},
         {"refresh-rate", required_argument, NULL, 0},
         {"composite", no_argument, NULL, 0},
-        
+
         {"time-align", required_argument, NULL, 0},
         {"date-align", required_argument, NULL, 0},
         {"layout-align", required_argument, NULL, 0},
@@ -1038,6 +1039,7 @@ int main(int argc, char *argv[]) {
         {"keylayout", required_argument, NULL, 0},
         {"timefont", required_argument, NULL, 0},
         {"datefont", required_argument, NULL, 0},
+        {"statusfont", required_argument, NULL, 0},
         {"layoutfont", required_argument, NULL, 0},
         {"timesize", required_argument, NULL, 0},
         {"datesize", required_argument, NULL, 0},
@@ -1323,6 +1325,14 @@ int main(int argc, char *argv[]) {
                         errx(1, "date font string can be at most 31 characters\n");
                     }
                     strcpy(date_font,optarg);
+                }
+                else if (strcmp(longopts[longoptind].name, "statusfont") == 0) {
+                    //read in to status_font
+                    if (strlen(optarg) > 31) {
+                        errx(1, "status font string can be at most 31 "
+                                "characters\n");
+                    }
+                    strcpy(status_font,optarg);
                 }
                 else if (strcmp(longopts[longoptind].name, "timesize") == 0) {
                     char *arg = optarg;

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -96,6 +96,7 @@ extern char time_format[32];
 extern char date_format[32];
 extern char time_font[32];
 extern char date_font[32];
+extern char status_font[32];
 extern char layout_font[32];
 extern char ind_x_expr[32];
 extern char ind_y_expr[32];
@@ -304,7 +305,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         cairo_rectangle(xcb_ctx, 0, 0, resolution[0], resolution[1]);
         cairo_fill(xcb_ctx);
     }
-    
+
 
     /* https://github.com/ravinrabbid/i3lock-clock/commit/0de3a411fa5249c3a4822612c2d6c476389a1297 */
     time_t rawtime;
@@ -397,7 +398,8 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         char buf[4];
 
         cairo_set_source_rgba(ctx, (double)text16->red/255, (double)text16->green/255, (double)text16->blue/255, (double)text16->alpha/255);
-        cairo_select_font_face(ctx, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+        cairo_select_font_face(ctx, status_font, CAIRO_FONT_SLANT_NORMAL,
+                CAIRO_FONT_WEIGHT_NORMAL);
         cairo_set_font_size(ctx, text_size);
         switch (auth_state) {
             case STATE_AUTH_VERIFY:
@@ -544,7 +546,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
             cairo_set_font_size(date_ctx, date_size);
 
             cairo_text_extents(date_ctx, date, &extents);
-            
+
             switch(date_align) {
                 case 1:
                     x = 0;
@@ -557,9 +559,9 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                     x = CLOCK_WIDTH/2 - ((extents.width / 2) + extents.x_bearing);
                     break;
             }
-            
+
             y = CLOCK_HEIGHT/2;
-            
+
             cairo_move_to(date_ctx, x, y);
             cairo_show_text(date_ctx, date);
             cairo_close_path(date_ctx);
@@ -582,13 +584,13 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
                     x = CLOCK_WIDTH/2 - ((extents.width / 2) + extents.x_bearing);
                     break;
             }
-            
+
             y = CLOCK_HEIGHT/2;
-            
+
             cairo_move_to(layout_ctx, x, y);
             cairo_show_text(layout_ctx, layout_text);
             cairo_close_path(layout_ctx);
-        
+
         }
     }
 


### PR DESCRIPTION
Time font and date font were existing settings, but status font was hardcoded. This PR adds a flag statusfont which sets the font for the "verifying..." messages and such.

It also removes extraneous whitespace in the edited files.