### PR TITLE
Give some indication in the output of 'i3lock -v' whether user is using i3lock or i3lock-color

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -1296,7 +1296,7 @@ int main(int argc, char *argv[]) {
     while ((o = getopt_long(argc, argv, optstring, longopts, &longoptind)) != -1) {
         switch (o) {
             case 'v':
-                errx(EXIT_SUCCESS, "version " I3LOCK_VERSION " © 2010 Michael Stapelberg");
+                errx(EXIT_SUCCESS, "version " I3LOCK_VERSION " (i3lock-color) © 2010 Michael Stapelberg");
             case 'n':
                 dont_fork = true;
                 break;


### PR DESCRIPTION
This way, it would be easier to change the behaviour of a shell script based on the version of i3lock the user has installed. There is probably a cleaner way of implementing this; my commit is but a suggestion.