### PR TITLE
jpg.h: add include for sys/types.h and define _GNU_SOURCE.

### DIFF
--- a/jpg.h
+++ b/jpg.h
@@ -1,6 +1,9 @@
 #ifndef _JPG_H
 #define _JPG_H
 
+#include <sys/types.h>
+
+#define _GNU_SOURCE 1
 typedef struct {
     uint height;
     uint width;


### PR DESCRIPTION
this allows us to use uint on musl libc systems like Void Linux and
Alpine.

Created as a consequence of someone trying to add the package to Void Linux https://github.com/void-linux/void-packages/pull/451