### PR TITLE
Also pass screen brightness keys as media keys

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -660,6 +660,8 @@ static void handle_key_press(xcb_key_press_event_t *event) {
             case XKB_KEY_XF86AudioMute:
             case XKB_KEY_XF86AudioLowerVolume:
             case XKB_KEY_XF86AudioRaiseVolume:
+            case XKB_KEY_XF86MonBrightnessUp:
+            case XKB_KEY_XF86MonBrightnessDown:
                 xcb_send_event(conn, true, screen->root, XCB_EVENT_MASK_BUTTON_PRESS, (char *)event);
                 return;
         }


### PR DESCRIPTION
For laptops it might be useful to change the screen brightness from the lockscreen, e.g., if the environment you want to unlock it in is a lot brighter than when you locked it. Adding it to the media key option seems sensible to me, since those keys perform similar functions.