### PR TITLE
Treat anything that's not a directory as a file

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -262,10 +262,10 @@ bool bar_reversed = false;
 /*
  * Checks if the given path leads to an actual file or something else, e.g. a directory
  */
-int is_regular_file(const char *path) {
+int is_directory(const char *path) {
     struct stat path_stat;
     stat(path, &path_stat);
-    return S_ISREG(path_stat.st_mode);
+    return !S_ISDIR(path_stat.st_mode);
 }
 
 /*
@@ -1956,7 +1956,7 @@ int main(int argc, char *argv[]) {
 
     init_colors_once();
     if (image_path != NULL) {
-        if (is_regular_file(image_path)) {
+        if (!is_directory(image_path)) {
             img = load_image(image_path);
         } else {
             /* Path to a directory is provided -> use slideshow mode */


### PR DESCRIPTION
With the changes to upstream i3lock in https://github.com/PandorasFox/i3lock-color/pull/120, people may start piping image data into i3lock's stdin. In order to remain a drop-in replacement with i3lock, i3lock-color has to treat stdin as a file and not as a directory.