### PR TITLE
Add long option for media key passing to docs

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -138,7 +138,7 @@ Captures the screen and blurs it using the given sigma (radius).
 Images may still be overlaid over the blurred screenshot.
 
 .TP
-.B \-m,
+.B \-m, \-\-pass-media-keys
 Allow the following keys to be used while the screen is locked by passing them through:
 XF86AudioPlay, XF86AudioPause, XF86AudioStop, XF86AudioPrev, XF86AudioNext, XF86AudioMute, XF86AudioLowerVolume, XF86AudioRaiseVolume,  XF86MonBrightnessUp, XF86MonBrightnessDown.
 


### PR DESCRIPTION
This documents the long option `--pass-media-keys` (which is synonym for `-m`). I guess this got lost in #116.