### PR TITLE
fix text alignment x position calculation

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -303,7 +303,7 @@ static void draw_text(cairo_t *ctx, text_t text) {
             break;
         case 0:
         default:
-            x = text.x - ((extents.width / 2) + (extents.x_bearing / 2));
+            x = text.x - extents.x_advance / 2;
             break;
     }
 


### PR DESCRIPTION
Even if I use a monospace font for the time string, the horizontal position of the string seems to change from time to time, as shown in the following gif.

![out](https://user-images.githubusercontent.com/1715589/67925620-d7092600-fbee-11e9-8e1d-7d59c6d9a037.gif)

Notice how the time string moves back and forth a little bit between 10 to 15 seconds.

This can be solved by using `x_advance` instead of `width` and `x_bearing` of `cairo_text_extents_t`.