### PR TITLE
Add --pass-volume-keys option to just pass volume keys

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -200,6 +200,11 @@ Allow the following keys to be used while the screen is locked by passing them t
 XF86PowerDown, XF86PowerOff, XF86Sleep.
 
 .TP
+.B \-\-pass\-volume\-keys
+Allow the following keys to be used while the screen is locked by passing them through:
+XF86AudioMute, XF86AudioLowerVolume, XF86AudioRaiseVolume.
+
+.TP
 .B \-\-insidevercolor=rrggbbaa
 Sets the interior circle color while the password is being verified.
 

--- a/i3lock.c
+++ b/i3lock.c
@@ -236,6 +236,7 @@ bool skip_repeated_empty_password = false;
 bool pass_media_keys = false;
 bool pass_screen_keys = false;
 bool pass_power_keys = false;
+bool pass_volume_keys = false;
 
 // for the rendering thread, so we can clean it up
 pthread_t draw_thread;
@@ -695,6 +696,17 @@ static void handle_key_press(xcb_key_press_event_t *event) {
             case XKB_KEY_XF86PowerDown:
             case XKB_KEY_XF86PowerOff:
             case XKB_KEY_XF86Sleep:
+                xcb_send_event(conn, true, screen->root, XCB_EVENT_MASK_BUTTON_PRESS, (char *)event);
+                return;
+        }
+    }
+
+    // volume keys
+    if (pass_volume_keys) {
+        switch(ksym) {
+            case XKB_KEY_XF86AudioMute:
+            case XKB_KEY_XF86AudioLowerVolume:
+            case XKB_KEY_XF86AudioRaiseVolume:
                 xcb_send_event(conn, true, screen->root, XCB_EVENT_MASK_BUTTON_PRESS, (char *)event);
                 return;
         }
@@ -1467,6 +1479,7 @@ int main(int argc, char *argv[]) {
         {"pass-media-keys", no_argument, NULL, 601},
         {"pass-screen-keys", no_argument, NULL, 602},
         {"pass-power-keys", no_argument, NULL, 603},
+        {"pass-volume-keys", no_argument, NULL, 604},
 
         // bar indicator stuff
         {"bar-indicator", no_argument, NULL, 700},
@@ -1942,6 +1955,9 @@ int main(int argc, char *argv[]) {
 				break;
 			case 603:
 				pass_power_keys = true;
+				break;
+			case 604:
+				pass_volume_keys = true;
 				break;
 
 			// Bar indicator


### PR DESCRIPTION
## Description
- Add `--pass-volume-keys` option to just pass volume control keys
- Rationale: It is often useful to be able to control volume while the screen is locked, but `--pass-media-keys` also passes the play/pause/stop/prev/next keys, which can cause information leakage -- it's easy to see what audio the last user was listening to.

Note that this PR preserves the existing behavior of `--pass-media-keys` (i.e. continuing to allow volume keys) for backwards compatibility; that can be changed if there are concerns.

### Screenshots/screencaps
N/A

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: Add --pass-volume-keys option to just pass volume keys
