### PR TITLE
Partial fix for memleak, standardize exit codes and ensure LF EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+text eol=lf

--- a/i3lock.c
+++ b/i3lock.c
@@ -893,10 +893,36 @@ static void process_xkb_event(xcb_generic_event_t *gevent) {
                                   event->state_notify.baseGroup,
                                   event->state_notify.latchedGroup,
                                   event->state_notify.lockedGroup);
-			if (layout_text != NULL) {
-				free(layout_text);
-				layout_text = NULL;
-			}
+            /* TODO: freeing layout_text when mode is 2 throws:
+            =================================================================
+            ==2600==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x602000000919 in thread T0
+                #0 0x7f3065b0e7cf in __interceptor_free (/lib/x86_64-linux-gnu/libasan.so.5+0x10d7cf)
+                #1 0x55c93c97e736 in process_xkb_event ../../i3lock-color/i3lock.c:898
+                #2 0x55c93c980458 in xcb_check_cb ../../i3lock-color/i3lock.c:1237
+                #3 0x7f306512bbc2 in ev_invoke_pending (/lib/x86_64-linux-gnu/libev.so.4+0x5bc2)
+                #4 0x7f306512fb92 in ev_run (/lib/x86_64-linux-gnu/libev.so.4+0x9b92)
+                #5 0x55c93c97c00c in ev_loop /usr/include/ev.h:842
+                #6 0x55c93c986762 in main ../../i3lock-color/i3lock.c:2325
+                #7 0x7f3064de70b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
+                #8 0x55c93c97920d in _start (/mnt/c/Users/raymo/Git/i3lock-color/build/i3lock+0x1520d)
+
+            0x602000000919 is located 9 bytes inside of 13-byte region [0x602000000910,0x60200000091d)
+            allocated by thread T0 here:
+                #0 0x7f3065b0ebc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
+                #1 0x55c93c99b20f in get_atom_name ../../i3lock-color/xcb.c:531
+                #2 0x55c93c99b9c2 in xcb_get_key_group_names ../../i3lock-color/xcb.c:607
+                #3 0x55c93c97c389 in get_keylayoutname ../../i3lock-color/i3lock.c:299
+                #4 0x55c93c984e44 in main ../../i3lock-color/i3lock.c:2118
+                #5 0x7f3064de70b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
+
+            SUMMARY: AddressSanitizer: bad-free (/lib/x86_64-linux-gnu/libasan.so.5+0x10d7cf) in __interceptor_free
+            ==2600==ABORTING
+            Not freeing results in memory leak.
+            */
+  			if (keylayout_mode == 1 && layout_text) {
+                  free(layout_text);
+                  layout_text = 0;
+            }
             layout_text = get_keylayoutname(keylayout_mode, conn);
             redraw_screen();
             break;
@@ -2328,10 +2354,6 @@ int main(int argc, char *argv[]) {
         pam_end(pam_handle, PAM_SUCCESS);
     }
 #endif
-	if (layout_text != NULL) {
-		free(layout_text);
-		layout_text = NULL;
-	}
 
     if (stolen_focus == XCB_NONE) {
         return 0;

--- a/i3lock.c
+++ b/i3lock.c
@@ -893,6 +893,10 @@ static void process_xkb_event(xcb_generic_event_t *gevent) {
                                   event->state_notify.baseGroup,
                                   event->state_notify.latchedGroup,
                                   event->state_notify.lockedGroup);
+			if (layout_text != NULL) {
+				free(layout_text);
+				layout_text = NULL;
+			}
             layout_text = get_keylayoutname(keylayout_mode, conn);
             redraw_screen();
             break;
@@ -1217,7 +1221,7 @@ static void xcb_check_cb(EV_P_ ev_check *w, int revents) {
 
                     /* In the parent process, we exit */
                     if (fork() != 0)
-                        exit(0);
+                        exit(EXIT_SUCCESS);
 
                     ev_loop_fork(EV_DEFAULT);
                 }
@@ -1344,7 +1348,7 @@ static void load_slideshow_images(const char *path, char *image_raw_format) {
     d = opendir(path);
     if (d == NULL) {
         printf("Could not open directory: %s\n", path);
-        exit(0);
+        exit(EXIT_SUCCESS);
     }
 
     while ((dir = readdir(d)) != NULL) {
@@ -2100,8 +2104,6 @@ int main(int argc, char *argv[]) {
         xcb_connection_has_error(conn))
             errx(EXIT_FAILURE, "Could not connect to X11, maybe you need to set DISPLAY?");
 
-
-
     if (xkb_x11_setup_xkb_extension(conn,
                                     XKB_X11_MIN_MAJOR_XKB_VERSION,
                                     XKB_X11_MIN_MINOR_XKB_VERSION,
@@ -2326,6 +2328,10 @@ int main(int argc, char *argv[]) {
         pam_end(pam_handle, PAM_SUCCESS);
     }
 #endif
+	if (layout_text != NULL) {
+		free(layout_text);
+		layout_text = NULL;
+	}
 
     if (stolen_focus == XCB_NONE) {
         return 0;

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -610,7 +610,7 @@ static te_expr *compile_expression(const char *const from, const char *expressio
     te_expr *expr = te_compile(expression, variables, var_count, &te_err);
     if (te_err) {
         fprintf(stderr, "Failed to reason about '%s' given by '%s'\n", expression, from);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
     return expr;
 }


### PR DESCRIPTION
<!--
(Opional) What i3lock-color issue does this PR address? (for example, #1234)
-->
Partially resolves #184

### Screenshots/screencaps
<!--
Include screenshots or gifs if relevant.
-->

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes:
- Free `layout_text` only when `layout_mode` is 1 (still broken and added TODO for 2) to mitigate memory leak
- Standardize exit codes
- Autoperform LF normalization