### PR TITLE
Add option to hide modkey text

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -370,6 +370,10 @@ Sets the string to be shown while acquiring pointer and keyboard focus. Defaults
 Sets the string to be shown after failing to acquire pointer and keyboard focus. Defaults to "lock failed!".
 
 .TP
+.B \-\-no-modkey-text
+Hides the modkey indicator (Num, Caps Lock ...)
+
+.TP
 .B \-\-radius
 The radius of the circle. Defaults to 90.
 

--- a/i3lock.1
+++ b/i3lock.1
@@ -370,7 +370,7 @@ Sets the string to be shown while acquiring pointer and keyboard focus. Defaults
 Sets the string to be shown after failing to acquire pointer and keyboard focus. Defaults to "lock failed!".
 
 .TP
-.B \-\-no-modkey-text
+.B \-\-no-modkeytext
 Hides the modkey indicator (Num, Caps Lock ...)
 
 .TP

--- a/i3lock.c
+++ b/i3lock.c
@@ -92,17 +92,18 @@ char greetercolor[9] = "000000ff";
 
 /* int defining which display the lock indicator should be shown on. If -1, then show on all displays.*/
 int screen_number = 0;
+
 /* default is to use the supplied line color, 1 will be ring color, 2 will be to use the inside color for ver/wrong/etc */
 int internal_line_source = 0;
-/* bool for showing the clock; why am I commenting this? */
+
+/* refresh rate in seconds, default to 1s */
+float refresh_rate = 1.0;
+
 bool show_clock = false;
 bool slideshow_enabled = false;
 bool always_show_clock = false;
 bool show_indicator = false;
-float refresh_rate = 1.0;
-
-/* bool for hiding mod text */
-bool show_mod_text = true;
+bool show_modkey_text = true;
 
 /* there's some issues with compositing - upstream removed support for this, but we'll allow people to supply an arg to enable it */
 bool composite = false;
@@ -579,7 +580,7 @@ static void input_done(void) {
         else if (strcmp(mod_name, XKB_MOD_NAME_LOGO) == 0)
             mod_name = "Super";
 
-        if (show_mod_text)
+        if (show_modkey_text)
         {
             char *tmp;
             if (modifier_string == NULL) {
@@ -1777,7 +1778,7 @@ int main(int argc, char *argv[]) {
                 greeter_text = optarg;
                 break;
             case 519:
-                show_mod_text = false;
+                show_modkey_text = false;
                 break;
 
 			// Font stuff

--- a/i3lock.c
+++ b/i3lock.c
@@ -101,6 +101,9 @@ bool always_show_clock = false;
 bool show_indicator = false;
 float refresh_rate = 1.0;
 
+/* bool for hiding mod text */
+bool show_mod_text = true;
+
 /* there's some issues with compositing - upstream removed support for this, but we'll allow people to supply an arg to enable it */
 bool composite = false;
 /* time formatter strings for date/time
@@ -576,13 +579,16 @@ static void input_done(void) {
         else if (strcmp(mod_name, XKB_MOD_NAME_LOGO) == 0)
             mod_name = "Super";
 
-        char *tmp;
-        if (modifier_string == NULL) {
-            if (asprintf(&tmp, "%s", mod_name) != -1)
+        if (show_mod_text)
+        {
+            char *tmp;
+            if (modifier_string == NULL) {
+                if (asprintf(&tmp, "%s", mod_name) != -1)
+                    modifier_string = tmp;
+            } else if (asprintf(&tmp, "%s, %s", modifier_string, mod_name) != -1) {
+                free(modifier_string);
                 modifier_string = tmp;
-        } else if (asprintf(&tmp, "%s, %s", modifier_string, mod_name) != -1) {
-            free(modifier_string);
-            modifier_string = tmp;
+            }
         }
     }
 
@@ -1459,6 +1465,7 @@ int main(int argc, char *argv[]) {
         {"locktext", required_argument, NULL, 516},
         {"lockfailedtext", required_argument, NULL, 517},
         {"greetertext", required_argument, NULL, 518},
+        {"no-modkey-text", no_argument, NULL, 519},
 
         // fonts
         {"time-font", required_argument, NULL, 520},
@@ -1768,6 +1775,9 @@ int main(int argc, char *argv[]) {
                 break;
             case 518:
                 greeter_text = optarg;
+                break;
+            case 519:
+                show_mod_text = false;
                 break;
 
 			// Font stuff

--- a/i3lock.c
+++ b/i3lock.c
@@ -580,8 +580,7 @@ static void input_done(void) {
         else if (strcmp(mod_name, XKB_MOD_NAME_LOGO) == 0)
             mod_name = "Super";
 
-        if (show_modkey_text)
-        {
+        if (show_modkey_text) {
             char *tmp;
             if (modifier_string == NULL) {
                 if (asprintf(&tmp, "%s", mod_name) != -1)
@@ -1466,7 +1465,7 @@ int main(int argc, char *argv[]) {
         {"locktext", required_argument, NULL, 516},
         {"lockfailedtext", required_argument, NULL, 517},
         {"greetertext", required_argument, NULL, 518},
-        {"no-modkey-text", no_argument, NULL, 519},
+        {"no-modkeytext", no_argument, NULL, 519},
 
         // fonts
         {"time-font", required_argument, NULL, 520},


### PR DESCRIPTION
<!--
(Opional) What i3lock-color issue does this PR address? (for example, #1234)
-->
Closes #172 

## Description
 - Add an option to hide the modkey text (like num lock) : --no-modkeytext


## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: new option: --no-modkeytext to hide the modkey text (e.g. Num/Caps lock).
