### PR TITLE
Add outline color and width for every text element

### DIFF
--- a/fonts.h
+++ b/fonts.h
@@ -18,11 +18,11 @@ typedef struct text {
     bool show;
 
     char str[512];
-    double size;
+    double size, outline_width;
 
     cairo_font_face_t *font;
 
-    rgba_t color;
+    rgba_t color, outline_color;
     double x, y;
 
     int align;

--- a/fonts.h
+++ b/fonts.h
@@ -18,11 +18,13 @@ typedef struct text {
     bool show;
 
     char str[512];
-    double size, outline_width;
+    double size;
+    double outline_width;
 
     cairo_font_face_t *font;
 
-    rgba_t color, outline_color;
+    rgba_t color;
+    rgba_t outline_color;
     double x, y;
 
     int align;

--- a/i3lock.1
+++ b/i3lock.1
@@ -323,6 +323,14 @@ Sets the font used to render various strings.
 Sets the font size used to render various strings.
 
 .TP
+.B \-\-{time, date, layout, verif, wrong, greeter}outlinecolor=rrggbbaa
+Sets the color of the outline.
+
+.TP
+.B \-\-{time, date, layout, verif, wrong, greeter, modifier}outlinewidth=number
+Sets the width of the outline.
+
+.TP
 .B \-\-datepos="x position:y position"
 Sets the position for the date string. All the variables from \-\-indpos and \-\-timepos may be used, in addition to:
 .RS

--- a/i3lock.c
+++ b/i3lock.c
@@ -90,6 +90,13 @@ char bshlcolor[9] = "db3300ff";
 char separatorcolor[9] = "000000ff";
 char greetercolor[9] = "000000ff";
 
+char verifoutlinecolor[9] = "00000000";
+char wrongoutlinecolor[9] = "00000000";
+char layoutoutlinecolor[9] = "00000000";
+char timeoutlinecolor[9] = "00000000";
+char dateoutlinecolor[9] = "00000000";
+char greeteroutlinecolor[9] = "00000000";
+
 /* int defining which display the lock indicator should be shown on. If -1, then show on all displays.*/
 int screen_number = 0;
 
@@ -171,6 +178,14 @@ double layout_size = 14.0;
 double circle_radius = 90.0;
 double ring_width = 7.0;
 double greeter_size = 32.0;
+
+double timeoutlinewidth = 0;
+double dateoutlinewidth = 0;
+double verifoutlinewidth = 0;
+double wrongoutlinewidth = 0;
+double modifieroutlinewidth = 0;
+double layoutoutlinewidth = 0;
+double greeteroutlinewidth = 0;
 
 char* verif_text = "verifying…";
 char* wrong_text = "wrong!";
@@ -1435,6 +1450,14 @@ int main(int argc, char *argv[]) {
         {"separatorcolor", required_argument, NULL, 314},
         {"greetercolor", required_argument, NULL, 315},
 
+        // text outline colors
+        {"verifoutlinecolor", required_argument, NULL, 316},
+        {"wrongoutlinecolor", required_argument, NULL, 317},
+        {"layoutoutlinecolor", required_argument, NULL, 318},
+        {"timeoutlinecolor", required_argument, NULL, 319},
+        {"dateoutlinecolor", required_argument, NULL, 320},
+        {"greeteroutlinecolor", required_argument, NULL, 321},
+
         {"line-uses-ring", no_argument, NULL, 'r'},
         {"line-uses-inside", no_argument, NULL, 's'},
 
@@ -1495,6 +1518,15 @@ int main(int argc, char *argv[]) {
         {"indpos", required_argument, NULL, 547},
         {"greeterpos", required_argument, NULL, 548},
 
+        // text outline width
+        {"timeoutlinewidth", required_argument, NULL, 560},
+        {"dateoutlinewidth", required_argument, NULL, 561},
+        {"verifoutlinewidth", required_argument, NULL, 562},
+        {"wrongoutlinewidth", required_argument, NULL, 563},
+        {"modifieroutlinewidth", required_argument, NULL, 564},
+        {"layoutoutlinewidth", required_argument, NULL, 565},
+        {"greeteroutlinewidth", required_argument, NULL, 566},
+
 		// pass keys
         {"pass-media-keys", no_argument, NULL, 601},
         {"pass-screen-keys", no_argument, NULL, 602},
@@ -1547,6 +1579,15 @@ int main(int argc, char *argv[]) {
     }\
     if (strlen(arg) != 8 || sscanf(arg, "%08[0-9a-fA-F]", acolor) != 1)\
         errx(1, #acolor " is invalid, color must be given in 3 or 4-byte format: rrggbb[aa]\n");
+
+#define parse_outline_width(awidth)\
+    arg = optarg;\
+    if (sscanf(arg, "%lf", &awidth) != 1)\
+        errx(1, #awidth " must be a number\n");\
+    if (awidth < 0) {\
+        fprintf(stderr, #awidth " must be a positive double; ignoring...\n");\
+        awidth = 0;\
+    }
 
     while ((o = getopt_long(argc, argv, optstring, longopts, &longoptind)) != -1) {
         switch (o) {
@@ -1674,6 +1715,25 @@ int main(int argc, char *argv[]) {
             case 315:
                 parse_color(greetercolor);
                 break;
+            case  316:
+                parse_color(verifoutlinecolor);
+                break;
+            case  317:
+                parse_color(wrongoutlinecolor);
+                break;
+            case  318:
+                parse_color(layoutoutlinecolor);
+                break;
+            case  319:
+                parse_color(timeoutlinecolor);
+                break;
+            case  320:
+                parse_color(dateoutlinecolor);
+                break;
+            case  321:
+                parse_color(greeteroutlinecolor);
+                break;
+
 
 			// General indicator opts
             case 400:
@@ -1970,6 +2030,30 @@ int main(int argc, char *argv[]) {
                     errx(1, "indpos must be of the form x:y\n");
                 }
                 break;
+
+            // text outline width
+            case 560:
+                parse_outline_width(timeoutlinewidth);
+                break;
+            case 561:
+                parse_outline_width(dateoutlinewidth);
+                break;
+            case 562:
+                parse_outline_width(verifoutlinewidth);
+                break;
+            case 563:
+                parse_outline_width(wrongoutlinewidth);
+                break;
+            case 564:
+                parse_outline_width(modifieroutlinewidth);
+                break;
+            case 565:
+                parse_outline_width(layoutoutlinewidth);
+                break;
+            case 566:
+                parse_outline_width(greeteroutlinewidth);
+                break;
+
 
 			// Pass keys
 			case 601:

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -94,6 +94,13 @@ extern char separatorcolor[9];
 extern char greetercolor[9];
 extern int internal_line_source;
 
+extern char verifoutlinecolor[9];
+extern char wrongoutlinecolor[9];
+extern char layoutoutlinecolor[9];
+extern char timeoutlinecolor[9];
+extern char dateoutlinecolor[9];
+extern char greeteroutlinecolor[9];
+
 extern int screen_number;
 extern float refresh_rate;
 
@@ -136,6 +143,14 @@ extern double wrong_size;
 extern double modifier_size;
 extern double layout_size;
 extern double greeter_size;
+
+extern double timeoutlinewidth;
+extern double dateoutlinewidth;
+extern double verifoutlinewidth;
+extern double wrongoutlinewidth;
+extern double modifieroutlinewidth;
+extern double layoutoutlinewidth;
+extern double greeteroutlinewidth;
 
 extern char *verif_text;
 extern char *wrong_text;
@@ -193,6 +208,13 @@ rgba_t sep16;
 rgba_t bar16;
 rgba_t greeter16;
 rgba_t background;
+
+rgba_t verifoutline16;
+rgba_t wrongoutline16;
+rgba_t layoutoutline16;
+rgba_t timeoutline16;
+rgba_t dateoutline16;
+rgba_t greeteroutline16;
 
 // experimental bar stuff
 
@@ -311,8 +333,12 @@ static void draw_text(cairo_t *ctx, text_t text) {
 
     cairo_set_source_rgba(ctx, text.color.red, text.color.green, text.color.blue, text.color.alpha);
     cairo_move_to(ctx, x, text.y);
-    cairo_show_text(ctx, text.str);
 
+    cairo_text_path(ctx, text.str);
+    cairo_fill_preserve(ctx);
+
+    cairo_set_source_rgba(ctx, text.outline_color.red, text.outline_color.green, text.outline_color.blue, text.outline_color.alpha);
+    cairo_set_line_width(ctx, text.outline_width);
     cairo_stroke(ctx);
 }
 
@@ -603,6 +629,13 @@ void init_colors_once(void) {
     colorgen(&tmp, bar_base_color, &bar16);
     colorgen(&tmp, greetercolor, &greeter16);
     colorgen(&tmp, color, &background);
+
+    colorgen(&tmp, verifoutlinecolor, &verifoutline16);
+    colorgen(&tmp, wrongoutlinecolor, &wrongoutline16);
+    colorgen(&tmp, layoutoutlinecolor, &layoutoutline16);
+    colorgen(&tmp, timeoutlinecolor, &timeoutline16);
+    colorgen(&tmp, dateoutlinecolor, &dateoutline16);
+    colorgen(&tmp, greeteroutlinecolor, &greeteroutline16);
 }
 
 static te_expr *compile_expression(const char *const from, const char *expression, const te_variable *variables, int var_count) {
@@ -733,7 +766,9 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
                 strncpy(draw_data.status_text.str, verif_text, sizeof(draw_data.status_text.str) - 1);
                 draw_data.status_text.font = get_font_face(VERIF_FONT);
                 draw_data.status_text.color = verif16;
+                draw_data.status_text.outline_color = verifoutline16;
                 draw_data.status_text.size = verif_size;
+                draw_data.status_text.outline_width = verifoutlinewidth;
                 draw_data.status_text.align = verif_align;
                 break;
             case STATE_AUTH_LOCK:
@@ -741,7 +776,9 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
                 strncpy(draw_data.status_text.str, lock_text, sizeof(draw_data.status_text.str) - 1);
                 draw_data.status_text.font = get_font_face(VERIF_FONT);
                 draw_data.status_text.color = verif16;
+                draw_data.status_text.outline_color = verifoutline16;
                 draw_data.status_text.size = verif_size;
+                draw_data.status_text.outline_width = verifoutlinewidth;
                 draw_data.status_text.align = verif_align;
                 break;
             case STATE_AUTH_WRONG:
@@ -749,7 +786,9 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
                 strncpy(draw_data.status_text.str, wrong_text, sizeof(draw_data.status_text.str) - 1);
                 draw_data.status_text.font = get_font_face(WRONG_FONT);
                 draw_data.status_text.color = wrong16;
+                draw_data.status_text.outline_color = wrongoutline16;
                 draw_data.status_text.size = wrong_size;
+                draw_data.status_text.outline_width = wrongoutlinewidth;
                 draw_data.status_text.align = wrong_align;
                 break;
             case STATE_I3LOCK_LOCK_FAILED:
@@ -757,7 +796,9 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
                 strncpy(draw_data.status_text.str, lock_failed_text, sizeof(draw_data.status_text.str) - 1);
                 draw_data.status_text.font = get_font_face(WRONG_FONT);
                 draw_data.status_text.color = wrong16;
+                draw_data.status_text.outline_color = wrongoutline16;
                 draw_data.status_text.size = wrong_size;
+                draw_data.status_text.outline_width = wrongoutlinewidth;
                 draw_data.status_text.align = wrong_align;
                 break;
             default:
@@ -766,7 +807,9 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
                     strncpy(draw_data.status_text.str, noinput_text, sizeof(draw_data.status_text.str) - 1);
                     draw_data.status_text.font = get_font_face(WRONG_FONT);
                     draw_data.status_text.color = wrong16;
+                    draw_data.status_text.outline_color = wrongoutline16;
                     draw_data.status_text.size = wrong_size;
+                    draw_data.status_text.outline_width = wrongoutlinewidth;
                     draw_data.status_text.align = wrong_align;
                     break;
                 }
@@ -774,7 +817,9 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
                     draw_data.status_text.show = true;
                     draw_data.status_text.font = get_font_face(WRONG_FONT);
                     draw_data.status_text.color = wrong16;
+                    draw_data.status_text.outline_color = wrongoutline16;
                     draw_data.status_text.size = wrong_size;
+                    draw_data.status_text.outline_width = wrongoutlinewidth;
                     draw_data.status_text.align = wrong_align;
                     // TODO: variable for this
                     draw_data.status_text.size = 32.0;
@@ -792,17 +837,21 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
         draw_data.mod_text.show = true;
         strncpy(draw_data.mod_text.str, modifier_string, sizeof(draw_data.mod_text.str) - 1);
         draw_data.mod_text.size = modifier_size;
+        draw_data.mod_text.outline_width = modifieroutlinewidth;
         draw_data.mod_text.font = get_font_face(WRONG_FONT);
         draw_data.mod_text.align = modif_align;
         draw_data.mod_text.color = wrong16;
+        draw_data.mod_text.outline_color = wrongoutline16;
     }
 
     if (layout_text) {
         draw_data.keylayout_text.show = true;
         strncpy(draw_data.keylayout_text.str, layout_text, sizeof(draw_data.keylayout_text.str) - 1);
         draw_data.keylayout_text.size = layout_size;
+        draw_data.keylayout_text.outline_width = layoutoutlinewidth;
         draw_data.keylayout_text.font = get_font_face(LAYOUT_FONT);
         draw_data.keylayout_text.color = layout16;
+        draw_data.keylayout_text.outline_color = layoutoutline16;
         draw_data.keylayout_text.align = layout_align;
     }
 
@@ -810,8 +859,10 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
         draw_data.greeter_text.show = true;
         strncpy(draw_data.greeter_text.str, greeter_text, sizeof(draw_data.greeter_text.str) - 1);
         draw_data.greeter_text.size = greeter_size;
+        draw_data.greeter_text.outline_width = greeteroutlinewidth;
         draw_data.greeter_text.font = get_font_face(GREETER_FONT);
         draw_data.greeter_text.color = greeter16;
+        draw_data.greeter_text.outline_color = greeteroutline16;
         draw_data.greeter_text.align = greeter_align;
     }
 
@@ -825,7 +876,9 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
         if (*draw_data.time_text.str) {
             draw_data.time_text.show = true;
             draw_data.time_text.size = time_size;
+            draw_data.time_text.outline_width = timeoutlinewidth;
             draw_data.time_text.color = time16;
+            draw_data.time_text.outline_color = timeoutline16;
             draw_data.time_text.font = get_font_face(TIME_FONT);
             draw_data.time_text.align = time_align;
         }
@@ -833,7 +886,9 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
         if (*draw_data.date_text.str) {
             draw_data.date_text.show = true;
             draw_data.date_text.size = date_size;
+            draw_data.date_text.outline_width = dateoutlinewidth;
             draw_data.date_text.color = date16;
+            draw_data.date_text.outline_color = dateoutline16;
             draw_data.date_text.font = get_font_face(DATE_FONT);
             draw_data.date_text.align = date_align;
         }
@@ -841,7 +896,9 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
         if (*draw_data.greeter_text.str) {
             draw_data.greeter_text.show = true;
             draw_data.greeter_text.size = greeter_size;
+            draw_data.greeter_text.outline_width = greeteroutlinewidth;
             draw_data.greeter_text.color = greeter16;
+            draw_data.greeter_text.outline_color = greeteroutline16;
             draw_data.greeter_text.font = get_font_face(GREETER_FONT);
             draw_data.greeter_text.align = greeter_align;
         }


### PR DESCRIPTION
Define outline colors, i.e. --timeoutlinecolor=FFFF00FF
Define outline width, i.e. --timeoutlinewidth=0.75

New arguments:
```
        --verifoutlinecolor
        --wrongoutlinecolor
        --layoutoutlinecolor
        --timeoutlinecolor
        --dateoutlinecolor
        --greeteroutlinecolor

        --timeoutlinewidth
        --dateoutlinewidth
        --verifoutlinewidth
        --wrongoutlinewidth
        --modifieroutlinewidth
        --layoutoutlinewidth
        --greeteroutlinewidth
```
Closes #147

## Description
 - 

### Screenshots/screencaps
```
./i3lock -n --keylayout 1 --clock \
  --datecolor=ffffffff --dateoutlinecolor=000000ff --datesize=50 --dateoutlinewidth=0.8 \
  --timecolor=000000ff --timeoutlinecolor=ffffffff --timesize=50 --timeoutlinewidth=0.9 \
  --layoutcolor=000000ff --layoutoutlinecolor=aa00aaaa --layoutsize=38 --layoutoutlinewidth=0.8 \
   -B 4
```
![scrot](https://user-images.githubusercontent.com/16379308/105767335-db87d000-5f52-11eb-9c7e-1189b657ae76.png)


## Release notes
Notes: Added outline color and width for every text element
