### PR TITLE
unrecognized option '--textsize=20' in lock.sh

### DIFF
--- a/lock.sh
+++ b/lock.sh
@@ -37,7 +37,7 @@ V='#bb00bbbb'  # verifying
 
 # --veriftext="Drinking verification can..."
 # --wrongtext="Nope!"
-# --textsize=20
+# --timesize=20
 # --modsize=10
 # --timefont=comic-sans
 # --datefont=monofur


### PR DESCRIPTION
## Description
 - I've replaced --textsize with --timesize in the commented text sample of lock.sh since the former option doesn't exist.
