### PR TITLE
Add --bar-total-width option

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -437,12 +437,17 @@ The value by which the bars decrease each time the screen is redrawn.
 
 .TP
 .B \-\-bar\-position
-Works similarly to the time/date/indicator expressions. If the bar is horizontal, this sets the vertical offset from the top edge.
-If it's vertically oriented, this sets the horizontal offset from the left edge.
+Works similarly to the time/date/indicator expressions. If only one number is provided, this sets
+the vertical offset from the top or left edge. If two numbers are provided in the form of x:y, sets
+the starting position of the bar.
 
 .TP
-.B \-\-bar\-count=10
+.B \-\-bar\-count
 Sets the number of minibars to draw on each screen.
+
+.TP
+.B \-\-bar\-total\-width
+The total width of the bar. Can be an expression.
 
 .TP
 .B \-\-no\-verify

--- a/i3lock.c
+++ b/i3lock.c
@@ -2142,7 +2142,7 @@ int main(int argc, char *argv[]) {
             case 711:
                 arg = optarg;
                 if (sscanf(arg, "%31s", bar_width_expr) != 1) {
-                    errx(1, "bar-width missing\n");
+                    errx(1, "bar-total-width missing\n");
                 }
                 break;
 

--- a/i3lock.c
+++ b/i3lock.c
@@ -2142,7 +2142,7 @@ int main(int argc, char *argv[]) {
             case 711:
                 arg = optarg;
                 if (sscanf(arg, "%31s", bar_width_expr) != 1) {
-                    errx(1, "bar-total-width missing\n");
+                    errx(1, "missing argument for bar-total-width\n");
                 }
                 break;
 

--- a/i3lock.c
+++ b/i3lock.c
@@ -1550,7 +1550,7 @@ int main(int argc, char *argv[]) {
         {"bar-periodic-step", required_argument, NULL, 708},
         {"bar-position", required_argument, NULL, 709},
         {"bar-count", required_argument, NULL, 710},
-        {"bar-width1", required_argument, NULL, 711},
+        {"bar-total-width", required_argument, NULL, 711},
 
         // misc.
         {"redraw-thread", no_argument, NULL, 900},

--- a/i3lock.c
+++ b/i3lock.c
@@ -282,7 +282,9 @@ int bar_width = 0;
 int bar_orientation = BAR_FLAT;
 
 char bar_base_color[9] = "000000ff";
-char bar_expr[32] = "0\0";
+char bar_x_expr[32] = "0";
+char bar_y_expr[32] = ""; // empty string on y means use x as offset based on orientation
+char bar_width_expr[32] = ""; // empty string means full width based on bar orientation
 bool bar_bidirectional = false;
 bool bar_reversed = false;
 
@@ -1548,6 +1550,7 @@ int main(int argc, char *argv[]) {
         {"bar-periodic-step", required_argument, NULL, 708},
         {"bar-position", required_argument, NULL, 709},
         {"bar-count", required_argument, NULL, 710},
+        {"bar-width1", required_argument, NULL, 711},
 
         // misc.
         {"redraw-thread", no_argument, NULL, 900},
@@ -2125,20 +2128,21 @@ int main(int argc, char *argv[]) {
                     bar_periodic_step = opt;
                 break;
             case 709:
-                //read in to ind_x_expr and ind_y_expr
-                if (strlen(optarg) > 31) {
-                    // this is overly restrictive since both the x and y string buffers have size 32, but it's easier to check.
-                    errx(1, "indicator position string can be at most 31 characters\n");
-                }
                 arg = optarg;
-                if (sscanf(arg, "%31s", bar_expr) != 1) {
-                    errx(1, "bar-position must be of the form [pos] with a max length of 31\n");
+                if (sscanf(arg, "%31[^:]:%31[^:]", bar_x_expr, bar_y_expr) < 1) {
+                    errx(1, "bar-position must be a single number or of the form x:y with a max length of 31\n");
                 }
                 break;
             case 710:
                 bar_count = atoi(optarg);
                 if (bar_count > MAX_BAR_COUNT || bar_count < MIN_BAR_COUNT) {
                     errx(1, "bar-count must be between %d and %d\n", MIN_BAR_COUNT, MAX_BAR_COUNT);
+                }
+                break;
+            case 711:
+                arg = optarg;
+                if (sscanf(arg, "%31s", bar_width_expr) != 1) {
+                    errx(1, "bar-width missing\n");
                 }
                 break;
 

--- a/unlock_indicator.h
+++ b/unlock_indicator.h
@@ -34,8 +34,8 @@ typedef struct {
 
     double indicator_x, indicator_y;
 
-    double screen_x, screen_y, screen_w, screen_h;
-    double bar_offset;
+    double screen_x, screen_y;
+    double bar_x, bar_y, bar_width;
 } DrawData;
 
 void render_lock(uint32_t* resolution, xcb_drawable_t drawable);


### PR DESCRIPTION
<!--
(Opional) What i3lock-color issue does this PR address? (for example, #1234)
-->
Closes #205 

## Description
This PR adds a --bar-total-width option to set the total width of the bar. And extends --bar-position option to set both x and y position

### Screenshots/screencaps
<!--
Include screenshots or gifs if relevant.
-->
```
i3lock --bar-indicator --bar-position "x+0.1*w:y+0.3*h" --bar-total-width "0.8*w" --bar-count 10 --no-verif
```
![2021-02-17-221548_2560x1440_scrot](https://user-images.githubusercontent.com/15951245/108300129-c4ad5580-716d-11eb-94be-565ae9587c4d.png)

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes:

- `--bar-position` now supports x:y format
- Add new option `--bar-total-width` to set the total bar width
