### PR TITLE
Add more modkey text color options to make it more flexible

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -212,7 +212,7 @@ Sets the color of highlight arcs on the ring upon keypress and backspace.
 Sets the color of the seperators at both ends of the highlight arcs on the ring.
 
 .TP
-.B \-\-{verif, wrong}\-color=rrggbbaa
+.B \-\-{verif, wrong, modif}\-color=rrggbbaa
 Sets the color of the status text while verifying and when password is wrong.
 
 .TP
@@ -281,7 +281,7 @@ modifier and greeter texts.
 .RE
 
 .TP
-.B \-\-{time, date, layout, verif, wrong, greeter}outline\-color=rrggbbaa
+.B \-\-{time, date, layout, verif, wrong, greeter, modif}outline\-color=rrggbbaa
 Sets the color of the outlines.
 
 .TP

--- a/i3lock.c
+++ b/i3lock.c
@@ -85,7 +85,7 @@ char wrongcolor[9] = "000000ff";
 char layoutcolor[9] = "000000ff";
 char timecolor[9] = "000000ff";
 char datecolor[9] = "000000ff";
-char modifcolor[9] = "ffffffff";
+char modifcolor[9] = "000000ff";
 char keyhlcolor[9] = "33db00ff";
 char bshlcolor[9] = "db3300ff";
 char separatorcolor[9] = "000000ff";
@@ -96,8 +96,8 @@ char wrongoutlinecolor[9] = "00000000";
 char layoutoutlinecolor[9] = "00000000";
 char timeoutlinecolor[9] = "00000000";
 char dateoutlinecolor[9] = "00000000";
-char modifoutlinecolor[9] = "00000000";
 char greeteroutlinecolor[9] = "00000000";
+char modifoutlinecolor[9] = "00000000";
 
 /* int defining which display the lock indicator should be shown on. If -1, then show on all displays.*/
 int screen_number = 0;
@@ -1466,8 +1466,8 @@ int main(int argc, char *argv[]) {
         {"layoutoutline-color", required_argument, NULL, 318},
         {"timeoutline-color", required_argument, NULL, 319},
         {"dateoutline-color", required_argument, NULL, 320},
-        {"modifoutline-color", required_argument, NULL, 323},
         {"greeteroutline-color", required_argument, NULL, 321},
+        {"modifoutline-color", required_argument, NULL, 323},
 
         {"line-uses-ring", no_argument, NULL, 'r'},
         {"line-uses-inside", no_argument, NULL, 's'},

--- a/i3lock.c
+++ b/i3lock.c
@@ -85,6 +85,7 @@ char wrongcolor[9] = "000000ff";
 char layoutcolor[9] = "000000ff";
 char timecolor[9] = "000000ff";
 char datecolor[9] = "000000ff";
+char modifcolor[9] = "ffffffff";
 char keyhlcolor[9] = "33db00ff";
 char bshlcolor[9] = "db3300ff";
 char separatorcolor[9] = "000000ff";
@@ -95,6 +96,7 @@ char wrongoutlinecolor[9] = "00000000";
 char layoutoutlinecolor[9] = "00000000";
 char timeoutlinecolor[9] = "00000000";
 char dateoutlinecolor[9] = "00000000";
+char modifoutlinecolor[9] = "00000000";
 char greeteroutlinecolor[9] = "00000000";
 
 /* int defining which display the lock indicator should be shown on. If -1, then show on all displays.*/
@@ -1452,6 +1454,7 @@ int main(int argc, char *argv[]) {
         {"layout-color", required_argument, NULL, 309},
         {"time-color", required_argument, NULL, 310},
         {"date-color", required_argument, NULL, 311},
+        {"modif-color", required_argument, NULL, 322},
         {"keyhl-color", required_argument, NULL, 312},
         {"bshl-color", required_argument, NULL, 313},
         {"separator-color", required_argument, NULL, 314},
@@ -1463,6 +1466,7 @@ int main(int argc, char *argv[]) {
         {"layoutoutline-color", required_argument, NULL, 318},
         {"timeoutline-color", required_argument, NULL, 319},
         {"dateoutline-color", required_argument, NULL, 320},
+        {"modifoutline-color", required_argument, NULL, 323},
         {"greeteroutline-color", required_argument, NULL, 321},
 
         {"line-uses-ring", no_argument, NULL, 'r'},
@@ -1739,6 +1743,12 @@ int main(int argc, char *argv[]) {
                 break;
             case  321:
                 parse_color(greeteroutlinecolor);
+                break;
+            case  322:
+                parse_color(modifcolor);
+                break;
+            case  323:
+                parse_color(modifoutlinecolor);
                 break;
 
 

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -100,8 +100,8 @@ extern char wrongoutlinecolor[9];
 extern char layoutoutlinecolor[9];
 extern char timeoutlinecolor[9];
 extern char dateoutlinecolor[9];
-extern char modifoutlinecolor[9];
 extern char greeteroutlinecolor[9];
+extern char modifoutlinecolor[9];
 
 extern int screen_number;
 extern float refresh_rate;
@@ -217,8 +217,8 @@ rgba_t wrongoutline16;
 rgba_t layoutoutline16;
 rgba_t timeoutline16;
 rgba_t dateoutline16;
-rgba_t modifoutline16;
 rgba_t greeteroutline16;
+rgba_t modifoutline16;
 
 // experimental bar stuff
 
@@ -597,8 +597,8 @@ void init_colors_once(void) {
     colorgen(&tmp, layoutoutlinecolor, &layoutoutline16);
     colorgen(&tmp, timeoutlinecolor, &timeoutline16);
     colorgen(&tmp, dateoutlinecolor, &dateoutline16);
-    colorgen(&tmp, modifoutlinecolor, &modifoutline16);
     colorgen(&tmp, greeteroutlinecolor, &greeteroutline16);
+    colorgen(&tmp, modifoutlinecolor, &modifoutline16);
 }
 
 static te_expr *compile_expression(const char *const from, const char *expression, const te_variable *variables, int var_count) {

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -88,6 +88,7 @@ extern char wrongcolor[9];
 extern char layoutcolor[9];
 extern char timecolor[9];
 extern char datecolor[9];
+extern char modifcolor[9];
 extern char keyhlcolor[9];
 extern char bshlcolor[9];
 extern char separatorcolor[9];
@@ -99,6 +100,7 @@ extern char wrongoutlinecolor[9];
 extern char layoutoutlinecolor[9];
 extern char timeoutlinecolor[9];
 extern char dateoutlinecolor[9];
+extern char modifoutlinecolor[9];
 extern char greeteroutlinecolor[9];
 
 extern int screen_number;
@@ -202,6 +204,7 @@ rgba_t wrong16;
 rgba_t layout16;
 rgba_t time16;
 rgba_t date16;
+rgba_t modif16;
 rgba_t keyhl16;
 rgba_t bshl16;
 rgba_t sep16;
@@ -214,6 +217,7 @@ rgba_t wrongoutline16;
 rgba_t layoutoutline16;
 rgba_t timeoutline16;
 rgba_t dateoutline16;
+rgba_t modifoutline16;
 rgba_t greeteroutline16;
 
 // experimental bar stuff
@@ -580,6 +584,7 @@ void init_colors_once(void) {
     colorgen(&tmp, layoutcolor, &layout16);
     colorgen(&tmp, timecolor, &time16);
     colorgen(&tmp, datecolor, &date16);
+    colorgen(&tmp, modifcolor, &modif16);
     colorgen(&tmp, keyhlcolor, &keyhl16);
     colorgen(&tmp, bshlcolor, &bshl16);
     colorgen(&tmp, separatorcolor, &sep16);
@@ -592,6 +597,7 @@ void init_colors_once(void) {
     colorgen(&tmp, layoutoutlinecolor, &layoutoutline16);
     colorgen(&tmp, timeoutlinecolor, &timeoutline16);
     colorgen(&tmp, dateoutlinecolor, &dateoutline16);
+    colorgen(&tmp, modifoutlinecolor, &modifoutline16);
     colorgen(&tmp, greeteroutlinecolor, &greeteroutline16);
 }
 
@@ -797,8 +803,8 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
         draw_data.mod_text.outline_width = modifieroutlinewidth;
         draw_data.mod_text.font = get_font_face(WRONG_FONT);
         draw_data.mod_text.align = modif_align;
-        draw_data.mod_text.color = wrong16;
-        draw_data.mod_text.outline_color = wrongoutline16;
+        draw_data.mod_text.color = modif16;
+        draw_data.mod_text.outline_color = modifoutline16;
     }
 
     if (layout_text) {


### PR DESCRIPTION

exension of Closes #208 

## Description

Support added for `--modif-color`, `--modifoutline-color`

 Previously modifier text colors are effected  only with
`--wrong-color` and `--wrongoutline-color` options.

Which is quite inconvient for modifier keys. So I separate them which
make it more flexible to color the modifier text.



## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: 
* More modkey text (e.g. Num/Caps lock) color options: `--modif-color`, `--modifoutline-color`  added
