### PR TITLE
Fix old options still present in manpage

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -200,7 +200,7 @@ Sets the color for the line separating the inside circle and the outer ring.
 
 .TP
 .B \-\-line\-uses\-{inside, ring}
-Overrides \-\-linecolor. The line will match the {inside, ring} color.
+Overrides \-\-line\-color. The line will match the {inside, ring} color.
 Note: these two options conflict with each other.
 
 .TP
@@ -313,7 +313,7 @@ r - the unlock indicator radius.
 
 .TP
 .B \-\-time\-pos="x\-position:y\-position"
-Sets the position for the time string. All the variables from \-\-indpos may be
+Sets the position for the time string. All the variables from \-\-ind\-pos may be
 used, in addition to:
 .RS
 .RS
@@ -324,8 +324,8 @@ iy - the y value of the indicator on the current display.
 
 .TP
 .B \-\-date\-pos="x\-position:y\-position"
-Sets the position for the date string. All the variables from \-\-indpos and
-\-\-timepos may be used, in addition to:
+Sets the position for the date string. All the variables from \-\-ind\-pos and
+\-\-time\-pos may be used, in addition to:
 .RS
 .RS
 tx - the computed x value of the timestring, for the current display.
@@ -335,8 +335,8 @@ ty - the computed y value of the timestring, for the current display.
 
 .TP
 .B \-\-greeter\-pos="x\-position:y\-position"
-Sets the position for the greeter string. All the variables from \-\-indpos and
-\-\-timepos may be used.
+Sets the position for the greeter string. All the variables from \-\-ind\-pos and
+\-\-time\-pos may be used.
 
 .TP
 .B \-\-pass\-{media, screen, power, volume}\-keys


### PR DESCRIPTION
## Description
Fix references to some now-removed pre #208 options in the manpage
Stumbled on scripts breaking after update earlier today and was kinda confused by seeing 2 distinct versions of e.g. --time-pos coexisting in the manpage.

## Release notes
Notes: no-notes
