### PR TITLE
More background types

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -1436,7 +1436,7 @@ int main(int argc, char *argv[]) {
         {"centered", no_argument, NULL, 'C'},
         {"fill", no_argument, NULL, 'F'},
         {"scale", no_argument, NULL, 'L'},
-        {"scale", no_argument, NULL, 'M'},
+        {"max", no_argument, NULL, 'M'},
         {"ignore-empty-password", no_argument, NULL, 'e'},
         {"inactivity-timeout", required_argument, NULL, 'I'},
         {"show-failed-attempts", no_argument, NULL, 'f'},
@@ -1627,30 +1627,31 @@ int main(int argc, char *argv[]) {
                 break;
             case 't':
                 if(bg_type != NONE) {
-                    errx(EXIT_FAILURE, "i3lock-color: Options tiling, centered, and fill conflict.");
+                    errx(EXIT_FAILURE, "i3lock-color: Only one background type can be used.");
                 }
                 bg_type = TILE;
                 break;
             case 'C':
                 if(bg_type != NONE) {
-                    errx(EXIT_FAILURE, "i3lock-color: Options tiling, centered, and fill conflict.");
+                    errx(EXIT_FAILURE, "i3lock-color: Only one background type can be used.");
                 }
                 bg_type = CENTER;
                 break;
             case 'F':
                 if(bg_type != NONE) {
-                    errx(EXIT_FAILURE, "i3lock-color: Options tiling, centered, and fill conflict.");
+                    errx(EXIT_FAILURE, "i3lock-color: Only one background type can be used.");
                 }
                 bg_type = FILL;
+                break;
             case 'L':
                 if(bg_type != NONE) {
-                    errx(EXIT_FAILURE, "i3lock-color: Options tiling, centered, and fill conflict.");
+                    errx(EXIT_FAILURE, "i3lock-color: Only one background type can be used.");
                 }
                 bg_type = SCALE;
                 break;
             case 'M':
                 if(bg_type != NONE) {
-                    errx(EXIT_FAILURE, "i3lock-color: Options tiling, centered, and fill conflict.");
+                    errx(EXIT_FAILURE, "i3lock-color: Only one background type can be used.");
                 }
                 bg_type = MAX;
                 break;

--- a/i3lock.c
+++ b/i3lock.c
@@ -1577,7 +1577,7 @@ int main(int argc, char *argv[]) {
     if (getenv("WAYLAND_DISPLAY") != NULL)
         errx(EXIT_FAILURE, "i3lock is a program for X11 and does not work on Wayland. Try https://github.com/swaywm/swaylock instead");
 
-    char *optstring = "hvnbdc:p:ui:tCeI:frsS:kB:m";
+    char *optstring = "hvnbdc:p:ui:tCFLMeI:frsS:kB:m";
     char *arg = NULL;
     int opt = 0;
     char padded[9] = "ffffffff"; \

--- a/i3lock.c
+++ b/i3lock.c
@@ -1357,6 +1357,7 @@ static cairo_surface_t* load_image(char* image_path, char* image_raw_format) {
                 img = cairo_image_surface_create_for_data(jpg_data,
                         CAIRO_FORMAT_ARGB32, jpg_info.width, jpg_info.height,
                         jpg_info.stride);
+                free(jpg_data);
             }
     }
 
@@ -2384,6 +2385,7 @@ int main(int argc, char *argv[]) {
         cairo_surface_destroy(xcb_img);
 
         img = blur_img;
+        bg_type = NONE;
     }
 
     xcb_window_t stolen_focus = find_focused_window(conn, screen->root);

--- a/unlock_indicator.h
+++ b/unlock_indicator.h
@@ -38,8 +38,17 @@ typedef struct {
     double bar_x, bar_y, bar_width;
 } DrawData;
 
+typedef enum {
+    NONE,
+    TILE,
+    CENTER,
+    FILL,
+    SCALE,
+    MAX,
+} background_type_t;
+
 void render_lock(uint32_t* resolution, xcb_drawable_t drawable);
-void draw_image(uint32_t* resolution, cairo_t* xcb_ctx);
+void draw_image(uint32_t* resolution, cairo_surface_t* img, cairo_t* xcb_ctx);
 void init_colors_once(void);
 void redraw_screen(void);
 void clear_indicator(void);


### PR DESCRIPTION
## Description
Adds the following options:
- `--fill -F` scale background image to fill displays while maintaining aspect ratio
- `--max -M` scale background image to fill displays while maintaining aspect ratio, without clipping
- `--scale -L` scale background image to fill displays without maintaining aspect ratio

I also cleaned up the code for --centered a bit, making it reuse xr_resolutions instead of querying randr again.

### Screenshots/screencaps
Following images shows all the possible background types (black lines show the display boundaries).

Centered:
![centered](https://user-images.githubusercontent.com/15951245/120093819-bff02a00-c0ea-11eb-9c20-f105592070f5.png)

Tiling
![tiling](https://user-images.githubusercontent.com/15951245/120093826-c383b100-c0ea-11eb-9fb7-a00d316edba8.png)

Fill
![fill](https://user-images.githubusercontent.com/15951245/120093821-c088c080-c0ea-11eb-924b-b46648fe93a2.png)

Max
![max](https://user-images.githubusercontent.com/15951245/120093823-c1b9ed80-c0ea-11eb-95a7-ac835841a9ae.png)

Scale
![scale](https://user-images.githubusercontent.com/15951245/120093825-c2528400-c0ea-11eb-8821-4ab0b56b533a.png)

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: New background image options `--max`, `--fill`, and `--scale`.
