### PR TITLE
Improve background tiling on multimonitor setup

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -63,6 +63,7 @@ extern char *modifier_string;
 /* A Cairo surface containing the specified image (-i), if any. */
 extern cairo_surface_t *img;
 extern cairo_surface_t *img_slideshow[256];
+extern cairo_surface_t *blur_bg_img;
 extern int slideshow_image_count;
 extern int slideshow_interval;
 extern bool slideshow_random_selection;
@@ -697,12 +698,17 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
         }
     }
 
-    if (img) {
-        draw_image(resolution, img, xcb_ctx);
+    if (blur_bg_img) {
+        cairo_set_source_surface(xcb_ctx, blur_bg_img, 0, 0);
+        cairo_paint(xcb_ctx);
     } else {
         cairo_set_source_rgba(xcb_ctx, background.red, background.green, background.blue, background.alpha);
         cairo_rectangle(xcb_ctx, 0, 0, resolution[0], resolution[1]);
         cairo_fill(xcb_ctx);
+    }
+
+    if (img) {
+        draw_image(resolution, img, xcb_ctx);
     }
 
     /*

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -1144,13 +1144,19 @@ void draw_image(uint32_t* root_resolution, cairo_surface_t *img, cairo_t* xcb_ct
 
         case TILE:
             {
-                /* create a pattern and fill a rectangle as big as the screen */
-                cairo_pattern_t *pattern;
-                pattern = cairo_pattern_create_for_surface(img);
+                cairo_pattern_t *pattern = cairo_pattern_create_for_surface(img);
                 cairo_set_source(xcb_ctx, pattern);
                 cairo_pattern_set_extend(pattern, CAIRO_EXTEND_REPEAT);
-                cairo_rectangle(xcb_ctx, 0, 0, root_resolution[0], root_resolution[1]);
-                cairo_fill(xcb_ctx);
+
+                for (int i = 0; i < xr_screens; i++) {
+                    cairo_matrix_t matrix;
+                    cairo_matrix_init_translate(&matrix, -xr_resolutions[i].x, -xr_resolutions[i].y);
+                    cairo_pattern_set_matrix(pattern, &matrix);
+
+                    cairo_rectangle(xcb_ctx, xr_resolutions[i].x, xr_resolutions[i].y, xr_resolutions[i].width, xr_resolutions[i].height);
+                    cairo_fill(xcb_ctx);
+                }
+
                 cairo_pattern_destroy(pattern);
                 break;
             }


### PR DESCRIPTION
<!--
(Opional) What i3lock-color issue does this PR address? (for example, #1234)
-->

## Description
An additional improvemnet to #219. This PR improves background tiling on multi-monitor setup.

### Screenshots/screencaps
<!--
Include screenshots or gifs if relevant.
-->
Before: the background tiles the whole virtual desktop
![old](https://user-images.githubusercontent.com/15951245/120117785-dafb8200-c15c-11eb-8d03-12c9d9eda0a3.png)

After: the background tiles are aligned with (and contained in) each monitor
![new](https://user-images.githubusercontent.com/15951245/120117783-d931be80-c15c-11eb-9a8f-2225d66040f5.png)

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes:
