### PR TITLE
Fix not being able to use variables: bx, by ,r

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -869,7 +869,7 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
           scaling_factor, button_diameter_physical);
 
     // variable mapping for evaluating the clock position expression
-    const unsigned int vars_size = 11;
+    const unsigned int vars_size = 14;
     te_variable vars[] =
         {{"w", &width},
          {"h", &height},


### PR DESCRIPTION
<!--
(Opional) What i3lock-color issue does this PR address? (for example, #1234)
-->
Closes #223

## Description
This PR changes the value of the hardcoded vars_size variable to account for the new variables added in commit 085df46.

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: Variables `r`, `bx` and `by` work now.
