### PR TITLE
--pass-*-keys options (#136)

### DIFF
--- a/.github/workflows/Build Test.yml
+++ b/.github/workflows/Build Test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install deps
       run: |
         sudo apt update
-        sudo apt install pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
+        sudo apt install pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxcb-xtest0-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
     - name: Build
       run: ./build.sh
     - name: Check and distcheck

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,7 +66,7 @@ jobs:
 
     - run: |
         sudo apt-get update
-        sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
+        sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxcb-xtest0-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
         ./build.sh
 
     - name: Perform CodeQL Analysis

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The following dependencies will need to be installed for a successful build, dep
 ### Debian
 Run this command to install all dependencies:
 ```
-sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util0-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
+sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util0-dev libxcb-xrm-dev libxcb-xtest0-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
 ```
 If you still see missing packages during build after installing all of these dependencies, try following the steps [here](https://github.com/Raymo111/i3lock-color/issues/211#issuecomment-809891727).
 
@@ -95,7 +95,7 @@ sudo dnf install -y autoconf automake cairo-devel fontconfig gcc libev-devel lib
 ### Ubuntu 18/20.04 LTS
 Run this command to install all dependencies:
 ```
-sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
+sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxcb-xtest0-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
 ```
 
 ## Building i3lock-color

--- a/configure.ac
+++ b/configure.ac
@@ -97,7 +97,7 @@ AC_SEARCH_LIBS([iconv_open], [iconv], , [AC_MSG_FAILURE([cannot find the require
 
 dnl Each prefix corresponds to a source tarball which users might have
 dnl downloaded in a newer version and would like to overwrite.
-PKG_CHECK_MODULES([XCB], [xcb xcb-xkb xcb-xinerama xcb-randr xcb-composite])
+PKG_CHECK_MODULES([XCB], [xcb xcb-xkb xcb-xinerama xcb-randr xcb-composite xcb-xtest])
 PKG_CHECK_MODULES([XCB_IMAGE], [xcb-image])
 PKG_CHECK_MODULES([XCB_UTIL], [xcb-event xcb-util xcb-atom])
 PKG_CHECK_MODULES([XCB_UTIL_XRM], [xcb-xrm])

--- a/i3lock.1
+++ b/i3lock.1
@@ -390,10 +390,15 @@ volume - XF86AudioMute, XF86AudioLowerVolume, XF86AudioRaiseVolume
 
 .TP
 .B \-\-special\-passthrough
-Allowed keys to pass through the locked screen, with \-\-pass\-{media, screen,
+Allows special keys to pass through the locked screen, with \-\-pass\-{media, screen,
 power, volume}\-keys, are forcibly sent to the window manager or desktop
 environment in three steps: release keyboard, send key, and grab the keyboard.
 No other keys will be sent to the WM/DE.
+
+Note: ONLY use this option if the special keys are NOT passed through without it.
+This could be less safe than the default behavior since the keyboard is ungrabbed for
+the keys to be passed through. This HAS been tested though, so there SHOULDN'T be any
+security issues.
 
 .TP
 .B \-\-bar\-indicator

--- a/i3lock.1
+++ b/i3lock.1
@@ -389,6 +389,13 @@ volume - XF86AudioMute, XF86AudioLowerVolume, XF86AudioRaiseVolume
 .RE
 
 .TP
+.B \-\-special\-passthrough
+Allowed keys to pass through the locked screen, with \-\-pass\-{media, screen,
+power, volume}\-keys, are forcibly sent to the window manager or desktop
+environment in three steps: release keyboard, send key, and grab the keyboard.
+No other keys will be sent to the WM/DE.
+
+.TP
 .B \-\-bar\-indicator
 Replaces the usual ring indicator with a bar indicator. Comes with perks.
 

--- a/i3lock.1
+++ b/i3lock.1
@@ -391,8 +391,8 @@ volume - XF86AudioMute, XF86AudioLowerVolume, XF86AudioRaiseVolume
 .TP
 .B \-\-special\-passthrough
 Allows special keys to pass through the locked screen, with \-\-pass\-{media, screen,
-power, volume}\-keys, are forcibly sent to the window manager or desktop
-environment in three steps: release keyboard, send key, and grab the keyboard.
+power, volume}\-keys. Keystrokes are forcibly sent to the window manager or desktop
+environment in three steps: un-grab keyboard, send key, and re-grab the keyboard.
 No other keys will be sent to the WM/DE.
 
 Note: ONLY use this option if the special keys are NOT passed through without it.

--- a/i3lock.c
+++ b/i3lock.c
@@ -671,6 +671,7 @@ static void send_key_to_root(xcb_key_press_event_t *event, bool twice) {
     }
 
     xcb_grab_keyboard(conn, true, screen->root, XCB_CURRENT_TIME, XCB_GRAB_MODE_ASYNC, XCB_GRAB_MODE_ASYNC);
+    xcb_set_input_focus(conn, XCB_INPUT_FOCUS_PARENT /* revert_to */, win, XCB_CURRENT_TIME);
 }
 
 /*


### PR DESCRIPTION
<!--
(Opional) What i3lock-color issue does this PR address? (for example, #1234)
-->
Closes #136 

## Description
 - This could solve the `--pass-media-keys`, `--pass-screen-keys` and `--pass-power-keys` options
 - Uses `xtest` library and `xcb_test_fake_input` to send keys.
 - Ungrabs the keyboard, sends the key event, and grabs the keyboard again

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: Solves `--pass-media-keys`, `--pass-screen-keys` and `--pass-power-keys` options
