### PR TITLE
fix(typo): fix wrong greeter_y_expr and  typo error message in arguments parser.

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -171,7 +171,7 @@ char verif_y_expr[32] = "iy\0";
 char wrong_x_expr[32] = "ix\0";
 char wrong_y_expr[32] = "iy\0";
 char greeter_x_expr[32] = "ix\0";
-char greeter_y_expr[32] = "ix\0";
+char greeter_y_expr[32] = "iy\0";
 
 double time_size = 32.0;
 double date_size = 14.0;
@@ -2044,7 +2044,7 @@ int main(int argc, char *argv[]) {
                 }
                 arg = optarg;
                 if (sscanf(arg, "%30[^:]:%30[^:]", wrong_x_expr, wrong_y_expr) != 2) {
-                    errx(1, "verifpos must be of the form x:y\n");
+                    errx(1, "wrongpos must be of the form x:y\n");
                 }
                 break;
             case 544:
@@ -2089,11 +2089,11 @@ int main(int argc, char *argv[]) {
             case 548:
                 if (strlen(optarg) > 31) {
                     // this is overly restrictive since both the x and y string buffers have size 32, but it's easier to check.
-                    errx(1, "indicator position string can be at most 31 characters\n");
+                    errx(1, "greeter position string can be at most 31 characters\n");
                 }
                 arg = optarg;
                 if (sscanf(arg, "%30[^:]:%30[^:]", greeter_x_expr, greeter_y_expr) != 2) {
-                    errx(1, "indpos must be of the form x:y\n");
+                    errx(1, "greeterpos must be of the form x:y\n");
                 }
                 break;
 


### PR DESCRIPTION
 Some typo in arguments parser.


## Description
 

1.  typo in `greeter_y_expr`, make greeter position  wrong
2.  typo in error messages of  `--greeter-pos` and `--wrong-pos`

### Screenshots/screencaps
<!--
Include screenshots or gifs if relevant.
-->

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes:
