### PR TITLE
feat(control char): add basic control char support

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -8,7 +8,7 @@
 .fi
 ..
 
-.TH i3lock-color 1 "JUN 2021" Linux "User Manuals"
+.TH i3lock-color 1 "SEP 2021" Linux "User Manuals"
 
 .SH NAME
 i3lock-color \- improved screen locker
@@ -244,18 +244,22 @@ Sets text colors.
 .B \-\-time\-str="%H:%M:%S"
 Sets the format used for generating the time string.
 See strftime(3) for a full list of format specifiers.
+Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-date\-str="%A, %m %Y"
 Sets the format used for generating the date string.
+Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-verif\-text="verifying…"
 Sets the string to be shown while verifying the password/input/key/etc.
+Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-wrong\-text="wrong!"
 Sets the string to be shown upon entering an incorrect password.
+Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-keylayout mode
@@ -273,22 +277,27 @@ Modes are as follows:
 .TP
 .B \-\-noinput\-text="no input"
 Sets the string to be shown upon pressing backspace without anything to delete.
+Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-lock\-text="locking…"
 Sets the string to be shown while acquiring pointer and keyboard focus.
+Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-lockfailed\-text="lock failed!"
 Sets the string to be shown after failing to acquire pointer and keyboard focus.
+Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-greeter\-text=""
 Sets the greeter text.
+Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-no\-modkey\-text
 Hides the modkey indicator (Num, Caps Lock ...)
+Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-{time, date, layout, verif, wrong, modif, greeter}\-align
@@ -483,6 +492,25 @@ The interval to wait until switching to the next image.
 .TP
 .B \-\-slideshow\-random\-selection
 Randomize the order of the images.
+
+.SH CONTROL CHARACTERS
+Control characters (\\r \\n \\b \\t) are supported in text OPTIONS. Their behavior
+are almost as same as anywhere else.
+.TP
+.B Carriage Return(\\\\r)
+Move to the start of line (left edge).
+Notes: The rendered characters would still live there.
+.TP
+.B Line Feed(\\\\n)
+Move to start of next line (left edge).
+.TP
+.B Backspace(\\\\b)
+Overwrite last one char if exists.
+Notes: The rendered character would still live there.
+.TP
+.B Tab(\\\\t)
+Move to next tab stop position.The width of one character for moving is as same as character 'a'.
+Note: The width may be strange if the font is not mono-spaced.
 
 .SH SEE ALSO
 .IR xautolock(1)

--- a/i3lock.1
+++ b/i3lock.1
@@ -241,27 +241,6 @@ Sets the color of the status text while verifying and when password is wrong.
 Sets text colors.
 
 .TP
-.B \-\-time\-str="%H:%M:%S"
-Sets the format used for generating the time string.
-See strftime(3) for a full list of format specifiers.
-Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
-
-.TP
-.B \-\-date\-str="%A, %m %Y"
-Sets the format used for generating the date string.
-Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
-
-.TP
-.B \-\-verif\-text="verifying…"
-Sets the string to be shown while verifying the password/input/key/etc.
-Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
-
-.TP
-.B \-\-wrong\-text="wrong!"
-Sets the string to be shown upon entering an incorrect password.
-Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
-
-.TP
 .B \-\-keylayout mode
 Displays the keylayout. Positionable similar to date, time, and indicator.
 Modes are as follows:
@@ -274,30 +253,46 @@ Modes are as follows:
 2 - Displays just the contents of the parenthesis, i.e. "US"
 .RE
 
+.B For all following -str or -text options, some control characters
+.B (i.e. \\\\n, \\\\t) are supported. See \fBCONTROL CHARACTERS\fR
+.B for more details.
+
+.TP
+.B \-\-time\-str="%H:%M:%S"
+Sets the format used for generating the time string.
+See strftime(3) for a full list of format specifiers.
+
+.TP
+.B \-\-date\-str="%A, %m %Y"
+Sets the format used for generating the date string.
+
+.TP
+.B \-\-verif\-text="verifying…"
+Sets the string to be shown while verifying the password/input/key/etc.
+
+.TP
+.B \-\-wrong\-text="wrong!"
+Sets the string to be shown upon entering an incorrect password.
+
 .TP
 .B \-\-noinput\-text="no input"
 Sets the string to be shown upon pressing backspace without anything to delete.
-Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-lock\-text="locking…"
 Sets the string to be shown while acquiring pointer and keyboard focus.
-Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-lockfailed\-text="lock failed!"
 Sets the string to be shown after failing to acquire pointer and keyboard focus.
-Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-greeter\-text=""
 Sets the greeter text.
-Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-no\-modkey\-text
 Hides the modkey indicator (Num, Caps Lock ...)
-Some control chars are supported, see \fBCONTROL CHARACTERS\fR for more detail.
 
 .TP
 .B \-\-{time, date, layout, verif, wrong, modif, greeter}\-align
@@ -519,7 +514,14 @@ Note: The width may be strange if the font is not mono-spaced.
 .IR convert(1)
 \- feed a wide variety of image formats to i3lock
 
-.SH AUTHOR
+.SH HOMEPAGE
+https://github.com/Raymo111/i3lock-color
+
+Please report bugs and submit pull-requests as follows:
+For i3lock (upstream): https://github.com/i3/i3lock
+For i3lock-color (enhancements on top of i3lock): https://github.com/Raymo111/i3lock-color
+
+.SH AUTHORS
 Michael Stapelberg <michael+i3lock at stapelberg dot de>
 
 Jan-Erik Rediger <badboy at archlinux.us>

--- a/i3lock.1
+++ b/i3lock.1
@@ -8,7 +8,7 @@
 .fi
 ..
 
-.TH i3lock-color 1 "SEP 2021" Linux "User Manuals"
+.TH i3lock-color 1 "NOV 2021" Linux "User Manuals"
 
 .SH NAME
 i3lock-color \- improved screen locker

--- a/i3lock.1
+++ b/i3lock.1
@@ -8,7 +8,7 @@
 .fi
 ..
 
-.TH i3lock-color 1 "NOV 2021" Linux "User Manuals"
+.TH i3lock-color 1 "JAN 2022" Linux "User Manuals"
 
 .SH NAME
 i3lock-color \- improved screen locker

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -365,13 +365,15 @@ static void draw_text_with_cc(cairo_t *ctx, text_t text, double start_x) {
                 DEBUG("draw %c failed\n", text.str[start]);
             }
         }
-        if (is_cc && cur_cc < cc_count) {
+        if (is_cc && (cur_cc < cc_count)) {
             if (cc_configs[cur_cc][1] == CC_POS_CHANGE) {
                 char x_offset = cc_configs[cur_cc][2];
                 if (x_offset < 0 && x_offset > -nglyphs) {
                     x = glyphs[nglyphs+x_offset].x;
                 }
-            } // CC_POS_RESET is default for x
+            }  else if (cc_configs[cur_cc][1] == CC_POS_RESET) {
+                x = start_x;
+            }
             if (cc_configs[cur_cc][3] == CC_POS_CHANGE) {
                 lineno += cc_configs[cur_cc][4];
             } // CC_POS_KEEP is default for y

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -373,13 +373,21 @@ static void draw_text_with_cc(cairo_t *ctx, text_t text, double start_x) {
                 if (x_offset < 0 && x_offset > -nglyphs) {
                     x = glyphs[nglyphs+x_offset].x;
                 } else if (x_offset > 0) {
-                    x = glyphs[nglyphs - 1].x + x_offset * te.x_advance;
+                    if (nglyphs >= 1) { // the case is some leading control chars.(although there is none now)
+                        x = glyphs[nglyphs - 1].x + x_offset * te.x_advance;
+                    } else { // deal the leading control chars.
+                        x += x_offset * te.x_advance;
+                    }
                 }
             } else if (control_characters[cur_cc].x_behavior == CC_POS_RESET) {
                 x = start_x;
             } else if (control_characters[cur_cc].x_behavior == CC_POS_TAB) {
-                int advance = control_characters[cur_cc].x_behavior_arg - ((nglyphs - 1) % control_characters[cur_cc].x_behavior_arg);
-                x = glyphs[nglyphs - 1].x + advance * te.x_advance;
+                if (nglyphs > 0) { // there may be leading tab, such as '\t\t' or '\n\t'
+                    int advance = control_characters[cur_cc].x_behavior_arg - ((nglyphs - 1) % control_characters[cur_cc].x_behavior_arg);
+                    x = glyphs[nglyphs - 1].x + advance * te.x_advance;
+                } else { // deal the leading tab.
+                    x += control_characters[cur_cc].x_behavior_arg * te.x_advance;
+                }
             }
             if (control_characters[cur_cc].y_behavior == CC_POS_CHANGE) {
                 lineno += control_characters[cur_cc].y_behavior_arg;

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -254,7 +254,7 @@ static control_char_config_t control_characters[] = {
     {'\n', CC_POS_RESET, 0, CC_POS_CHANGE, 1},
     {'\b', CC_POS_CHANGE, -1, CC_POS_KEEP, 0},
     {'\r', CC_POS_RESET, 0, CC_POS_KEEP, 0},
-    {'\t', CC_POS_TAB, 8, CC_POS_KEEP, 0},
+    {'\t', CC_POS_TAB, 4, CC_POS_KEEP, 0},
 };
 size_t control_char_count = sizeof control_characters / sizeof(control_char_config_t);
 

--- a/unlock_indicator.h
+++ b/unlock_indicator.h
@@ -47,6 +47,22 @@ typedef enum {
     MAX,
 } background_type_t;
 
+
+typedef enum {
+    CC_POS_RESET,
+    CC_POS_CHANGE,
+    CC_POS_KEEP,
+    CC_POS_TAB
+} control_char_pos_t;
+
+typedef struct {
+    char character;
+    control_char_pos_t x_behavior;
+    int x_behavior_arg;
+    control_char_pos_t y_behavior;
+    int y_behavior_arg;
+} control_char_config_t;
+
 void render_lock(uint32_t* resolution, xcb_drawable_t drawable);
 void draw_image(uint32_t* resolution, cairo_surface_t* img, cairo_t* xcb_ctx);
 void init_colors_once(void);


### PR DESCRIPTION
Try to fix #138 

## Description
 - A basic solution for control chars render (\n, \r, \b, \t)

### reproduce

```bash
# any mono font is good.
./i3lock -t -e -f -n --no-verify \
    --greeter-pos=1200:500 \
    --greeter-font="Cascadia Code" \
    --greeter-text="A example
$(printf 'newline\nnewline')
$(printf 'carriage\rreturn')
$(printf 'newline\r\nreturn')
$(printf 'tab\ttab')
$(printf 'backspace\bbackspace')
$(printf '\rdef    def')
$(printf 'tabtab\ttab')
$(printf 'tabtabtab\ttab')"
```

### Screenshots/screencaps
<!--
Include screenshots or gifs if relevant.
-->

#### before fix.
![40639034-D623-4787-978B-FB434A7417D5](https://user-images.githubusercontent.com/3500109/132894584-b331921d-ffc2-4e9f-8978-3b6cddca2ee8.jpeg)


#### after fix.
![D09B2B22-AC0E-4174-9C5D-C384BDD04D7B](https://user-images.githubusercontent.com/3500109/133619793-fb024211-9af0-48f4-ba6a-f68d72cea910.jpeg)


## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: Support basic control chars.(\n \r \b \t)