### PR TITLE
Slideshow images loaded when needed (#241)

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -1441,7 +1441,6 @@ bool load_slideshow_images(const char *path) {
         strcat(path_to_image, dir->d_name);
 
         img_slideshow[file_count] = strdup(path_to_image);
-        printf("Adding: \"%s\" on %d\n", path_to_image, file_count);
 
         if (img_slideshow[file_count] != NULL) {
             ++file_count;

--- a/i3lock.c
+++ b/i3lock.c
@@ -28,6 +28,7 @@
 #include <err.h>
 #include <errno.h>
 #include <assert.h>
+#include <regex.h>
 #ifdef __OpenBSD__
 #include <bsd_auth.h>
 #else
@@ -244,8 +245,12 @@ static uint8_t xkb_base_event;
 static uint8_t xkb_base_error;
 static int randr_base = -1;
 
+char *image_path = NULL;
+char *image_raw_format = NULL;
+char *slideshow_path = NULL;
+
 cairo_surface_t *img = NULL;
-cairo_surface_t *img_slideshow[256];
+char *img_slideshow[256];
 cairo_surface_t *blur_bg_img = NULL;
 int slideshow_image_count = 0;
 int slideshow_interval = 10;
@@ -1368,7 +1373,7 @@ static void raise_loop(xcb_window_t window) {
 /*
  * Loads an image from the given path. Handles JPEG and PNG. Returns NULL in case of error.
  */
-static cairo_surface_t* load_image(char* image_path, char* image_raw_format) {
+cairo_surface_t* load_image(char* image_path) {
     cairo_surface_t *img = NULL;
     JPEG_INFO jpg_info;
 
@@ -1400,32 +1405,43 @@ static cairo_surface_t* load_image(char* image_path, char* image_raw_format) {
 }
 
 /*
- * Loads the images from the provided directory and stores them in the pointer array
+ * Reads the provided directory and stores the images path in the pointer array
  * img_slideshow
  */
-static void load_slideshow_images(const char *path, char *image_raw_format) {
+bool load_slideshow_images(const char *path) {
     slideshow_enabled = true;
     DIR *d;
     struct dirent *dir;
     int file_count = 0;
+    slideshow_image_count = 0;
+
+    DEBUG("Loading slideshow images at \"%s\"\n", path);
 
     d = opendir(path);
     if (d == NULL) {
         printf("Could not open directory: %s\n", path);
-        exit(EXIT_SUCCESS);
+        return false;
+    }
+
+    regex_t reg;
+
+    if (regcomp(&reg, ".*\\.(jpe?g|png)", REG_EXTENDED)) {
+        printf("Could not compile regex\n");
+        return false;
     }
 
     while ((dir = readdir(d)) != NULL) {
-        if (file_count >= 256) {
-            break;
-        }
+        if (file_count >= 256) break;
+        int result = regexec(&reg, dir->d_name, 0, NULL, 0);
+        if (result) continue;
 
         char path_to_image[256];
         strcpy(path_to_image, path);
         strcat(path_to_image, "/");
         strcat(path_to_image, dir->d_name);
 
-        img_slideshow[file_count] = load_image(path_to_image, image_raw_format);
+        img_slideshow[file_count] = strdup(path_to_image);
+        printf("Adding: \"%s\" on %d\n", path_to_image, file_count);
 
         if (img_slideshow[file_count] != NULL) {
             ++file_count;
@@ -1433,15 +1449,14 @@ static void load_slideshow_images(const char *path, char *image_raw_format) {
     }
 
     slideshow_image_count = file_count;
-
+    regfree(&reg);
     closedir(d);
+    return true;
 }
 
 int main(int argc, char *argv[]) {
     struct passwd *pw;
     char *username;
-    char *image_path = NULL;
-    char *image_raw_format = NULL;
 #ifndef __OpenBSD__
     int ret;
     struct pam_conv conv = {conv_callback, NULL};
@@ -2359,10 +2374,12 @@ int main(int argc, char *argv[]) {
     init_colors_once();
     if (image_path != NULL) {
         if (!is_directory(image_path)) {
-            img = load_image(image_path, image_raw_format);
+            img = load_image(image_path);
         } else {
             /* Path to a directory is provided -> use slideshow mode */
-            load_slideshow_images(image_path, image_raw_format);
+            slideshow_path = strdup(image_path);
+            if (!load_slideshow_images(slideshow_path)) exit(EXIT_FAILURE);
+            img = load_image(img_slideshow[0]);
         }
 
         free(image_path);

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -69,6 +69,7 @@ extern cairo_surface_t *blur_bg_img;
 extern int slideshow_image_count;
 extern int slideshow_interval;
 extern bool slideshow_random_selection;
+int slideshow_image_now = 0;
 
 unsigned long lastCheck;
 
@@ -693,12 +694,12 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
             if (slideshow_random_selection) {
                 img = load_image(img_slideshow[rand() % slideshow_image_count]);
             } else {
-                img = load_image(img_slideshow[current_slideshow_index++]);
-
-                if (current_slideshow_index >= slideshow_image_count) {
-                    current_slideshow_index = 0;
-                    load_slideshow_images(slideshow_path);
-                }
+                img = load_image(img_slideshow[current_slideshow_index]);
+            }
+            current_slideshow_index++;
+            if (current_slideshow_index >= slideshow_image_count) {
+                current_slideshow_index = 0;
+                load_slideshow_images(slideshow_path);
             }
             lastCheck = now;
         }

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -62,7 +62,9 @@ extern char *modifier_string;
 
 /* A Cairo surface containing the specified image (-i), if any. */
 extern cairo_surface_t *img;
-extern cairo_surface_t *img_slideshow[256];
+extern char *image_path;
+extern char *slideshow_path;
+extern char *img_slideshow[256];
 extern cairo_surface_t *blur_bg_img;
 extern int slideshow_image_count;
 extern int slideshow_interval;
@@ -160,6 +162,9 @@ extern char *lock_text;
 extern char *lock_failed_text;
 extern char *layout_text;
 extern char *greeter_text;
+
+bool load_slideshow_images(const char *path);
+cairo_surface_t* load_image(char* image_path);
 
 /* Whether the failed attempts should be displayed. */
 extern bool show_failed_attempts;
@@ -686,12 +691,13 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
         unsigned long now = (unsigned long)time(NULL);
         if (img == NULL || now - lastCheck >= slideshow_interval) {
             if (slideshow_random_selection) {
-                img = img_slideshow[rand() % slideshow_image_count];
+                img = load_image(img_slideshow[rand() % slideshow_image_count]);
             } else {
-                img = img_slideshow[current_slideshow_index++];
+                img = load_image(img_slideshow[current_slideshow_index++]);
 
                 if (current_slideshow_index >= slideshow_image_count) {
                     current_slideshow_index = 0;
+                    load_slideshow_images(slideshow_path);
                 }
             }
             lastCheck = now;


### PR DESCRIPTION
<!--
(Opional) What i3lock-color issue does this PR address? (for example, #1234)
-->
Closes #241 

## Description
 - Before these changes, slideshow images were loaded at startup, providing a static method to load them when required. Now, slideshow images are loaded when needed.
 - At first, images path are stored statically. After **slideshow-interval**, **i3lock** loads the next image; if all images were read, then reloads the images path, allowing to add/remove/change these images.
 - Also, only files that match an image type are stored in memory.

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: Slideshow images are loaded when needed