### PR TITLE
Revert indent

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,13 +14,13 @@ pamd_files = pam/i3lock
 pamd_DATA = $(pamd_files)
 
 if ENABLE_BASH_COMPLETION
-	bashcompletiondir = $(BASH_COMPLETION_DIR)
-	dist_bashcompletion_DATA = i3lock-bash
+bashcompletiondir = $(BASH_COMPLETION_DIR)
+dist_bashcompletion_DATA = i3lock-bash
 endif
 
 if ENABLE_ZSH_COMPLETION
-	zshcompletiondir = $(ZSH_COMPLETION_DIR)
-	dist_zshcompletion_DATA = i3lock-zsh
+zshcompletiondir = $(ZSH_COMPLETION_DIR)
+dist_zshcompletion_DATA = i3lock-zsh
 endif
 
 install-data-hook:


### PR DESCRIPTION
<!--
(Opional) What i3lock-color issue does this PR address? (for example, #1234)
-->

## Description
 - Reverts indentation made at 995f58dc7 inside `Makefile.am`
 - Bash and ZSH completions fixed

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: no-notes