### PR TITLE
build: disable debug and sanitizers by default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,12 @@
 #!/bin/sh -x
 
-configureOpts="--disable-sanitizers --disable-debug"
+configureOpts=""
 
 while getopts ":hd" opt; do
   case ${opt} in
     h ) echo "Use -d to turn on sanitizers (for debugging only)"
       exit;;
-    d ) configureOpts=""
+    d ) configureOpts="--enable-debug"
       ;;
     \? ) echo "Usage: $0 [-h] [-d]"
       exit;;

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AX_CODE_COVERAGE
 
 dnl is_release must be lowercase because AX_CHECK_ENABLE_DEBUG calls m4_tolower
 dnl on its fourth argument.
-AX_CHECK_ENABLE_DEBUG([yes], , [UNUSED_NDEBUG], [$is_release])
+AX_CHECK_ENABLE_DEBUG([no], , , [$is_release])
 
 AC_PROG_CC
 
@@ -132,14 +132,14 @@ AC_CHECK_HEADERS([fcntl.h float.h inttypes.h limits.h locale.h netinet/in.h path
 
 AC_CONFIG_FILES([Makefile])
 
-# Enable address sanitizer for non-release builds. The performance hit is a
+# Enable address sanitizer for debug builds. The performance hit is a
 # 50% increase of wallclock time for the testsuite on my machine.
-if test x$is_release = xyes; then
-	default_sanitizers=
-else
+if test "x$ax_enable_debug" = "xyes"; then
 	default_sanitizers=address
+else
+	default_sanitizers=
 fi
-AX_SANITIZERS(, [$default_sanitizers], [AC_DEFINE([I3LOCK_ASAN_ENABLED], [], [Enable ASAN])])
+AX_SANITIZERS(, [$default_sanitizers])
 
 AC_OUTPUT
 


### PR DESCRIPTION


<!--
(Opional) What i3lock-color issue does this PR address? (for example, #1234)
-->
Closes #[issue number]

## Description
 
Debug builds should never be the default. Change debug option to default to off and link it to sanitizer usage (rather than whether being built from git tree). Address sanitizers can cause a program to run twice as slow on top of the debug "-O0" non-optimisation. Also remove some unused macro variables.

From #239 to fix the inherited upstream _configure.ac_ particularly for those (including distros) not using _build.sh_ and just the  normal configure/make directly.

### Screenshots/screencaps
<!--
Include screenshots or gifs if relevant.
-->

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Disable debug build by default. Faster blurring.
