### PR TITLE
Add options to draw indicator as polygon

### DIFF
--- a/i3lock-bash
+++ b/i3lock-bash
@@ -93,6 +93,10 @@ _i3lock() {
   "--bar-pos"
   "--bar-count"
   "--bar-total-width"
+  # Polygon indicator
+  "--polygon-sides"
+  "--polygon-offset"
+  "--polygon-highlight"
   # Extra configs
   "--redraw-thread"
   "--refresh-rate"

--- a/i3lock-zsh
+++ b/i3lock-zsh
@@ -95,7 +95,7 @@ _i3lock() {
     "--bar-total-width[The total width of the bar]:float:"
     # Polygon indicator
     "--polygon-sides[Draws the indicator as a regular polygon]:int:"
-    "--polygon-offset[Rotates the indicator polygon]:float:"
+    "--polygon-rotation[Rotates the indicator polygon]:float:"
     "--polygon-highlight[Sets the polygon highlight mode]:mode:((0\:'random' 1\:'clockwise' 2\:'counterclockwise'))"
     # Extra configs
     "--redraw-thread[Starts a separate thread for redrawing the screen]"

--- a/i3lock-zsh
+++ b/i3lock-zsh
@@ -93,6 +93,10 @@ _i3lock() {
     "--bar-pos[Sets the bar position]:pos:->bar_pos"
     "--bar-count[Sets the number of minibars to draw on each screen]:int:"
     "--bar-total-width[The total width of the bar]:float:"
+    # Polygon indicator
+    "--polygon-sides[Draws the indicator as a regular polygon]:int:"
+    "--polygon-offset[Rotates the indicator polygon]:float:"
+    "--polygon-highlight[Sets the polygon highlight mode]:mode:((0\:'random' 1\:'clockwise' 2\:'counterclockwise'))"
     # Extra configs
     "--redraw-thread[Starts a separate thread for redrawing the screen]"
     "--refresh-rate[The refresh rate of the indicator]:double:"

--- a/i3lock.1
+++ b/i3lock.1
@@ -445,12 +445,11 @@ Sets the number of minibars to draw on each screen.
 The total width of the bar. Can be an expression.
 
 .TP
-.B \-\-polygon\-sides=0
-If set to an integer greater then 2, draw the indicator as a regular polygon
-instead of a circle.
+.B \-\-polygon\-sides
+Draw the indicator as a regular polygon instead of a circle.
 
 .TP
-.B \-\-polygon\-offset=degrees\-as\-double
+.B \-\-polygon\-rotation=degrees\-as\-double
 The angle to rotate the indicator polygon by.
 
 .TP

--- a/i3lock.1
+++ b/i3lock.1
@@ -445,6 +445,21 @@ Sets the number of minibars to draw on each screen.
 The total width of the bar. Can be an expression.
 
 .TP
+.B \-\-polygon\-sides=0
+If set to an integer greater then 2, draw the indicator as a regular polygon
+instead of a circle.
+
+.TP
+.B \-\-polygon\-offset=degrees\-as\-double
+The angle to rotate the indicator polygon by.
+
+.TP
+.B \-\-polygon\-highlight={0, 1, 2}
+Sets the highlight mode when drawing the indicator as a polygon. 0 highlights a
+random edge on each keypress, 1 highlights consecutive edges clockwise, 2 highlights
+counterclockwise. Highlights reverse direction while backspacing.
+
+.TP
 .B \-\-redraw\-thread
 Starts a separate thread for redrawing the screen. Potentially worse from a
 security standpoint, but makes the bar indicator still do its usual periodic

--- a/i3lock.c
+++ b/i3lock.c
@@ -294,6 +294,11 @@ char bar_width_expr[32] = ""; // empty string means full width based on bar orie
 bool bar_bidirectional = false;
 bool bar_reversed = false;
 
+// Polygon indicator
+int polygon_sides = 0;
+double polygon_offset = 0;
+int polygon_highlight = 0;
+
 /* isutf, u8_dec © 2005 Jeff Bezanson, public domain */
 #define isutf(c) (((c)&0xC0) != 0x80)
 
@@ -1493,6 +1498,9 @@ int main(int argc, char *argv[]) {
         {"indicator", no_argument, NULL, 401},
         {"radius", required_argument, NULL, 402},
         {"ring-width", required_argument, NULL, 403},
+        {"polygon-sides", required_argument, NULL, 404},
+        {"polygon-offset", required_argument, NULL, 405},
+        {"polygon-highlight", required_argument, NULL, 406},
 
         // alignment
         {"time-align", required_argument, NULL, 500},
@@ -1809,6 +1817,30 @@ int main(int argc, char *argv[]) {
                 if (ring_width < 1.0) {
                     fprintf(stderr, "ring-width must be a positive float; ignoring...\n");
                     ring_width = 7.0;
+                }
+                break;
+            case 404:
+                arg = optarg;
+                if (sscanf(arg, "%d", &polygon_sides) != 1)
+                    errx(1, "polygon-sides must be a number\n");
+                if (polygon_sides < 3 && polygon_sides != 0) {
+                    fprintf(stderr, "polygon-sides must be greater then 2 or 0; ignoring...\n");
+                    polygon_sides = 0;
+                }
+                break;
+            case 405:
+                arg = optarg;
+                if (sscanf(arg, "%lf", &polygon_offset) != 1)
+                    errx(1, "polygon-offset must be a number\n");
+                polygon_offset = polygon_offset * (M_PI / 180);
+                break;
+            case 406:
+                arg = optarg;
+                if (sscanf(arg, "%d", &polygon_highlight) != 1)
+                    errx(1, "polygon-highlight must be a number\n");
+                if (polygon_highlight < 0 || polygon_highlight > 2) {
+                    fprintf(stderr, "polygon-highlight must be between 0 and 2; ignoring...\n");
+                    polygon_highlight = 0;
                 }
                 break;
 

--- a/i3lock.c
+++ b/i3lock.c
@@ -296,7 +296,7 @@ bool bar_reversed = false;
 
 // Polygon indicator
 int polygon_sides = 0;
-double polygon_offset = 0;
+double polygon_rotation = 0;
 int polygon_highlight = 0;
 
 /* isutf, u8_dec © 2005 Jeff Bezanson, public domain */
@@ -1499,7 +1499,7 @@ int main(int argc, char *argv[]) {
         {"radius", required_argument, NULL, 402},
         {"ring-width", required_argument, NULL, 403},
         {"polygon-sides", required_argument, NULL, 404},
-        {"polygon-offset", required_argument, NULL, 405},
+        {"polygon-rotation", required_argument, NULL, 405},
         {"polygon-highlight", required_argument, NULL, 406},
 
         // alignment
@@ -1822,17 +1822,15 @@ int main(int argc, char *argv[]) {
             case 404:
                 arg = optarg;
                 if (sscanf(arg, "%d", &polygon_sides) != 1)
-                    errx(1, "polygon-sides must be a number\n");
-                if (polygon_sides < 3 && polygon_sides != 0) {
-                    fprintf(stderr, "polygon-sides must be greater then 2 or 0; ignoring...\n");
-                    polygon_sides = 0;
-                }
+                    errx(EXIT_FAILURE, "polygon-sides must be a number\n");
+                if (polygon_sides < 3)
+                    errx(EXIT_FAILURE, "polygon-sides must be greater then 2 or 0\n");
                 break;
             case 405:
                 arg = optarg;
-                if (sscanf(arg, "%lf", &polygon_offset) != 1)
-                    errx(1, "polygon-offset must be a number\n");
-                polygon_offset = polygon_offset * (M_PI / 180);
+                if (sscanf(arg, "%lf", &polygon_rotation) != 1)
+                    errx(1, "polygon-rotation must be a number\n");
+                polygon_rotation = polygon_rotation * (M_PI / 180);
                 break;
             case 406:
                 arg = optarg;

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -249,7 +249,7 @@ extern bool bar_reversed;
 
 // Polygon indicator
 extern int polygon_sides;
-extern double polygon_offset;
+extern double polygon_rotation;
 extern int polygon_highlight;
 
 static cairo_font_face_t *font_faces[6] = {
@@ -523,11 +523,21 @@ static void draw_bar(cairo_t *ctx, double bar_x, double bar_y, double bar_width,
     cairo_restore(ctx);
 }
 
-void draw_polygon(cairo_t *ctx, double center_x, double center_y, double radius, int points, int start, int end, double offset) {
+/* Draw some number of edges of a polygon
+ * center_x/center_y: The center of the polygon
+ * radius: The distance from the center to the vertices
+ * points: The number of verticies
+ * start/end: The index of the edges to draw. Settings start to 0 and end to
+ *            points will draw the entire polygon. Edges are indexed counter
+ *            clockwise around the polygon.
+ * angle_offset: How far offset clockwise the first vertex is from the positive
+ *               x axis (radians).
+ */
+void draw_polygon(cairo_t *ctx, double center_x, double center_y, double radius, int points, int start, int end, double angle_offset) {
     int count = end - start;
 
     for (int v = 0; v < count + 1; v++) {
-        double theta = (start + v)  * ((M_PI * 2) / points) + offset;
+        double theta = (start + v)  * ((M_PI * 2) / points) + angle_offset;
 
         int x = radius * cos(theta);
         int y = radius * sin(theta);
@@ -545,7 +555,7 @@ static void draw_indic(cairo_t *ctx, double ind_x, double ind_y) {
         /* Draw a (centered) circle with transparent background. */
         cairo_set_line_width(ctx, RING_WIDTH);
         if (polygon_sides > 0)
-            draw_polygon(ctx, ind_x, ind_y, BUTTON_RADIUS, polygon_sides, 0, polygon_sides, polygon_offset);
+            draw_polygon(ctx, ind_x, ind_y, BUTTON_RADIUS, polygon_sides, 0, polygon_sides, polygon_rotation);
         else
             cairo_arc(ctx, ind_x, ind_y, BUTTON_RADIUS, 0, 2 * M_PI);
 
@@ -618,7 +628,7 @@ static void draw_indic(cairo_t *ctx, double ind_x, double ind_y) {
             cairo_set_source_rgba(ctx, line16.red, line16.green, line16.blue, line16.alpha);
             cairo_set_line_width(ctx, 2.0);
             if (polygon_sides > 0)
-                draw_polygon(ctx, ind_x, ind_y, BUTTON_RADIUS - 5, polygon_sides, 0, polygon_sides, polygon_offset);
+                draw_polygon(ctx, ind_x, ind_y, BUTTON_RADIUS - 5, polygon_sides, 0, polygon_sides, polygon_rotation);
             else
                 cairo_arc(ctx, ind_x, ind_y, BUTTON_RADIUS - 5, 0, 2 * M_PI);
             cairo_stroke(ctx);
@@ -643,7 +653,7 @@ static void draw_indic(cairo_t *ctx, double ind_x, double ind_y) {
                     highlight_start = input_position % polygon_sides;
                 else if(polygon_highlight == 2)
                     highlight_start = -input_position % polygon_sides;
-                draw_polygon(ctx, ind_x, ind_y, BUTTON_RADIUS, polygon_sides, highlight_start, highlight_start+1, polygon_offset);
+                draw_polygon(ctx, ind_x, ind_y, BUTTON_RADIUS, polygon_sides, highlight_start, highlight_start+1, polygon_rotation);
                 cairo_stroke(ctx);
                 return;
             }


### PR DESCRIPTION
## Description
I needed a hexagon unlock indicator for my config, thought it turned out pretty neat and was worth sharing. This adds three new config options.

- `--polygon-sides=n` enables drawing a regular polygon instead of a circle for the indicator. It defaults to `0`, which draws a circle, and can be any integer greater then `2`.
- `--polygon-offset=d` specifies a rotation in degrees to apply to the polygon. At zero offset the first vertex is at `(ind_x+radius,ind_y)`.
- `--polygon-highlight={0,1,2}` defines the highlight mode while typing. `0` highlights a random edge on each keystroke. `1` highlights sequential edges walking clockwise around the indicator. `2` walks counter clockwise. The edge to highlight is based on the buffer position, so backspacing characters reverses the direction of rotation.

The value of `--radius` is the center to vertex distance of the polygon. `--line-*`, `--inside-*`, and `--ring-*` are all respected. Separators are not drawn.

### Screenshots/screencaps
![custom](https://user-images.githubusercontent.com/5875657/160267393-dd7b05ec-e854-4f2a-918d-59a0c0d2124b.gif)
![default](https://user-images.githubusercontent.com/5875657/160267498-c0e24e25-0a9e-4ae4-bbfb-96b814032aa1.gif)

## Release notes
Notes: Added config options to draw indicator as a polygon.
