### PR TITLE
Add GIF support for animated lock screen

### DIFF
--- a/.github/workflows/Build Test.yml
+++ b/.github/workflows/Build Test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install deps
       run: |
         sudo apt update
-        sudo apt install pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
+        sudo apt install pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev libgif-dev
     - name: Build
       run: ./build.sh
     - name: Check and distcheck

--- a/.github/workflows/Build Test.yml
+++ b/.github/workflows/Build Test.yml
@@ -18,7 +18,7 @@ jobs:
         make check
         make distcheck
     - name: Upload binary artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: i3lock
         path: /home/runner/work/i3lock-color/i3lock-color/build/i3lock

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,7 +66,7 @@ jobs:
 
     - run: |
         sudo apt-get update
-        sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
+        sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev libgif-dev
         ./build.sh
 
     - name: Perform CodeQL Analysis

--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,7 @@ AX_CHECK_BASH_COMPLETION
 AX_CHECK_ZSH_COMPLETION
 
 # Checks for header files.
-AC_CHECK_HEADERS([fcntl.h float.h inttypes.h limits.h locale.h netinet/in.h paths.h stddef.h stdint.h stdlib.h string.h sys/param.h sys/socket.h sys/time.h unistd.h], , [AC_MSG_FAILURE([cannot find the $ac_header header, which i3lock requires])])
+AC_CHECK_HEADERS([fcntl.h float.h inttypes.h limits.h locale.h netinet/in.h paths.h stddef.h stdint.h stdlib.h string.h sys/param.h sys/socket.h sys/time.h unistd.h gif_lib.h], , [AC_MSG_FAILURE([cannot find the $ac_header header, which i3lock requires])])
 
 AC_CONFIG_FILES([Makefile])
 

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,7 @@ AC_SEARCH_LIBS([ev_run], [ev], , [AC_MSG_FAILURE([cannot find the required ev_ru
 
 AC_SEARCH_LIBS([shm_open], [rt])
 
+AC_SEARCH_LIBS([DGifOpenFileName], [gif])
 # Use system-local-login instead of login on Arch and Gentoo
 if [[ -f /etc/arch-release ]] || [[ -f /etc/gentoo-release ]]; then
     echo "Using PAM for Arch/Gentoo"

--- a/i3lock.1
+++ b/i3lock.1
@@ -8,7 +8,7 @@
 .fi
 ..
 
-.TH i3lock-color 1 "SEP 2022" Linux "User Manuals"
+.TH i3lock-color 1 "MAR 2025" Linux "User Manuals"
 
 .SH NAME
 i3lock-color \- improved screen locker

--- a/i3lock.1
+++ b/i3lock.1
@@ -8,7 +8,7 @@
 .fi
 ..
 
-.TH i3lock-color 1 "JAN 2022" Linux "User Manuals"
+.TH i3lock-color 1 "SEP 2022" Linux "User Manuals"
 
 .SH NAME
 i3lock-color \- improved screen locker
@@ -42,8 +42,8 @@ i3lock forks, so you can combine it with an alias to suspend to RAM
 (run "i3lock && echo mem > /sys/power/state" to get a locked screen after waking
 up your computer from suspend to RAM)
 .IP \[bu]
-You can specify either a background color or a PNG image which will be displayed
-while your screen is locked.
+You can specify either a PNG or JPG image, a GIF animation or a background
+color which will be displayed while your screen is locked.
 .IP \[bu]
 You can specify whether i3lock should bell upon a wrong password.
 .IP \[bu]
@@ -73,12 +73,12 @@ verified or whether it is wrong).
 
 .TP
 .BI \-i\  path \fR,\ \fB\-\-image= path
-Display the given PNG image instead of a blank screen.
+Display the given PNG/JPG image or GIF animation instead of a blank screen.
 
 .TP
 .BI \fB\-\-raw= format
-Read the image given by \-\-image as a raw image instead of PNG. The argument is
-the image's format as <width>x<height>:<pixfmt>.
+Read the image given by \-\-image as a raw image instead of PNG/JPG/GIF. The
+argument is the image's format as <width>x<height>:<pixfmt>.
 The supported pixel formats are:
 \'native', 'rgb', 'xrgb', 'rgbx', 'bgr', 'xbgr', and 'bgrx'.
 The "native" pixel format expects a pixel as a 32-bit (4-byte) integer in

--- a/i3lock.c
+++ b/i3lock.c
@@ -1220,7 +1220,7 @@ static cairo_surface_t *read_gif_image(const char *image_path) {
                 case GRAPHICS_EXT_FUNC_CODE:
                     DGifExtensionToGCB(pext->ByteCount, pext->Bytes, &gc);
                     // Delay time is in [ms]. Scale it to seconds.
-                    gif_img[idx].delay_sec = gc.DelayTime*0.01;
+                    gif_img[idx].delay_sec = gc.DelayTime * 0.01;
                     break;
                 default:
                     gif_img[idx].delay_sec = 0;

--- a/i3lock.c
+++ b/i3lock.c
@@ -1241,16 +1241,16 @@ static cairo_surface_t *read_gif_image(const char *image_path) {
         switch (gc.DisposalMode) {
             case DISPOSE_DO_NOT:
                 if (data_prev) {
-                    memcpy(data, data_prev, width*height*sizeof(uint32_t));
+                    memcpy(data, data_prev, data_size);
                 } else {
-                    memset(data, 0, width*height*sizeof(uint32_t));
+                    memset(data, 0, data_size);
                 }
                 break;
             case DISPOSE_BACKGROUND:
-                memset(data, bg_color, width*height*sizeof(uint32_t));
+                memset(data, bg_color, data_size);
                 break;
             default:
-                memset(data, 0, width*height*sizeof(uint32_t));
+                memset(data, 0, data_size);
         }
 
         /* Read RGB */

--- a/jpg.c
+++ b/jpg.c
@@ -13,27 +13,17 @@
 /*
  * Checks if the file is a JPEG by looking for a valid JPEG header.
  */
-bool file_is_jpg(char* file_path) {
-    if (!file_path) return false;
-    FILE* image_file;
+bool file_is_jpg(FILE* image_file) {
     uint16_t file_header;
     size_t read_count;
     // TODO: Consider endianess on non-x86 platforms
     uint16_t jpg_magick = 0xd8ff;
 
-    image_file = fopen(file_path, "rb");
-    if (image_file == NULL) {
-        int img_err = errno;
-        fprintf(stderr, "Could not open image file %s: %s\n",
-                file_path, strerror(img_err));
-        return false;
-    }
-
+    fseek(image_file, 0, SEEK_SET);
     read_count = fread(&file_header, sizeof(file_header), 1, image_file);
-    fclose(image_file);
 
     if (read_count < 1) {
-        fprintf(stderr, "Error searching for JPEG header in %s\n", file_path);
+        fprintf(stderr, "Error searching for JPEG header\n");
         return false;
     }
 

--- a/jpg.h
+++ b/jpg.h
@@ -13,7 +13,7 @@ typedef struct {
 /*
  * Checks if the file is a JPEG by looking for a valid JPEG header.
  */
-bool file_is_jpg(char* file_path);
+bool file_is_jpg(FILE* image_file);
 
 /*
  * Reads a JPEG from a file into memory, in a format that Cairo can create a

--- a/travis/Dockerfile
+++ b/travis/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     build-essential clang git autoconf automake libxcb-randr0-dev pkg-config libpam0g-dev \
     libcairo2-dev libxcb1-dev libxcb-dpms0-dev libxcb-image0-dev libxcb-util0-dev \
     libxcb-xrm-dev libev-dev libxcb-xinerama0-dev libxcb-xkb-dev libxkbcommon-dev \
-    libxkbcommon-x11-dev clang-format-9 && \
+    libxkbcommon-x11-dev clang-format-9 libgif-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src


### PR DESCRIPTION
## Description
Use gif_lib to read a [GIF file](https://www.w3.org/Graphics/GIF/spec-gif89a.txt) and show animated lock screen.
Currently it supports only 0-2 disposal methods.

### Screenshots/screencaps
![demonstation](https://user-images.githubusercontent.com/21184954/174704230-72f919ad-05d1-4b07-bb0b-f9884675c409.gif)

## Release notes
Added support for animated GIF images.