### PR TITLE
Support for XF86AudioMicMute

### DIFF
--- a/i3lock-bash
+++ b/i3lock-bash
@@ -91,6 +91,7 @@ _i3lock() {
   "--cmd-audio-mute"
   "--cmd-volume-up"
   "--cmd-volume-down"
+  "--cmd-mic-mute"
   "--cmd-power-down"
   "--cmd-power-off"
   "--cmd-power-sleep"

--- a/i3lock-zsh
+++ b/i3lock-zsh
@@ -93,6 +93,7 @@ _i3lock() {
     "--cmd-volume-up[Command for XF86AudioRaiseVolume]"
     "--cmd-volume-down[Command for XF86AudioLowerVolume]"
     "--cmd-power-down[Command for XF86PowerDown] "
+    "--cmd-mic-mute[Command for XF86AudioMicMute]"
     "--cmd-power-off[Command for XF86PowerOff]"
     "--cmd-power-sleep[Command for XF86Sleep]"
     # Bar mode

--- a/i3lock.1
+++ b/i3lock.1
@@ -423,6 +423,8 @@ volume\-up - XF86AudioRaiseVolume
 .IP \[bu]
 volume\-down - XF86AudioLowerVolume
 .IP \[bu]
+mic\-mute - XF86AudioMicMute
+.IP \[bu]
 power\-down - XF86PowerDown
 .IP \[bu]
 power\-off - XF86PowerOff

--- a/i3lock.1
+++ b/i3lock.1
@@ -383,7 +383,8 @@ passing them through:
 .RS
 .IP \[bu] 2
 media - XF86AudioPlay, XF86AudioPause, XF86AudioStop, XF86AudioPrev,
-        XF86AudioNext, XF86AudioMute, XF86AudioLowerVolume, XF86AudioRaiseVolume
+        XF86AudioNext, XF86AudioMute, XF86AudioLowerVolume, XF86AudioRaiseVolume,
+        XF86AudioMicMute
 .IP \[bu]
 screen - XF86MonBrightnessUp, XF86MonBrightnessDown
 .IP \[bu]

--- a/i3lock.c
+++ b/i3lock.c
@@ -276,6 +276,7 @@ char* cmd_media_prev = NULL;
 char* cmd_audio_mute = NULL;
 char* cmd_volume_up = NULL;
 char* cmd_volume_down = NULL;
+char* cmd_mic_mute = NULL;
 
 char* cmd_power_down = NULL;
 char* cmd_power_off = NULL;
@@ -781,6 +782,12 @@ static void handle_key_press(xcb_key_press_event_t *event) {
             case XKB_KEY_XF86AudioRaiseVolume:
                 if (cmd_volume_up) {
                     system(cmd_volume_up);
+                    return;
+                }
+                break;
+            case XKB_KEY_XF86AudioMicMute:
+                if (cmd_mic_mute) {
+                    system(cmd_mic_mute);
                     return;
                 }
                 break;
@@ -1675,6 +1682,7 @@ int main(int argc, char *argv[]) {
         {"cmd-audio-mute", required_argument, NULL, 640},
         {"cmd-volume-up", required_argument, NULL, 641},
         {"cmd-volume-down", required_argument, NULL, 642},
+        {"cmd-mic-mute", required_argument, NULL, 643},
 
         {"cmd-power-down", required_argument, NULL, 650},
         {"cmd-power-off", required_argument, NULL, 651},
@@ -2276,6 +2284,9 @@ int main(int argc, char *argv[]) {
                 break;
             case 642:
                 cmd_volume_down = optarg;
+                break;
+            case 643:
+                cmd_mic_mute = optarg;
                 break;
 
             case 650:

--- a/i3lock.c
+++ b/i3lock.c
@@ -816,6 +816,7 @@ static void handle_key_press(xcb_key_press_event_t *event) {
             case XKB_KEY_XF86AudioMute:
             case XKB_KEY_XF86AudioLowerVolume:
             case XKB_KEY_XF86AudioRaiseVolume:
+            case XKB_KEY_XF86AudioMicMute:
                 xcb_send_event(conn, true, screen->root, XCB_EVENT_MASK_BUTTON_PRESS, (char *)event);
                 return;
         }


### PR DESCRIPTION
## Description
 - This change adds same functionality that exists for all the other media keys (passthrough, custom command) for the XF86AudioMicMute symbol.

### Screenshots/screencaps
No visual changes.

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes:
Add support for XF86AudioMicMute media key