### PR TITLE
Fix: Remove breaking space in zsh completion

### DIFF
--- a/i3lock-zsh
+++ b/i3lock-zsh
@@ -92,7 +92,8 @@ _i3lock() {
     "--cmd-audio-mute[Command for XF86AudioMute]"
     "--cmd-volume-up[Command for XF86AudioRaiseVolume]"
     "--cmd-volume-down[Command for XF86AudioLowerVolume]"
-    "--cmd-power-down[Command for XF86PowerDown] "
+    "--cmd-mic-mute[Command for XF86AudioMicMute]"
+    "--cmd-power-down[Command for XF86PowerDown]"
     "--cmd-power-off[Command for XF86PowerOff]"
     "--cmd-power-sleep[Command for XF86Sleep]"
     # Bar mode


### PR DESCRIPTION
## Description
 Previously, attempting to use the `_i3lock` file placed into `$ZSH_COMPLETION_DIR` (`/usr/share/zsh/vendor-completions/` on my system) would result in the following error:
 ```
 _arguments:comparguments:327: invalid option definition: --cmd-power-down[Command for XF86PowerDown]
```
This change fixes the source of the error, allowing completion to work again.

### Screenshots/screencaps
No visual changes.

## Release notes
Notes:
Fix: Remove breaking space in zsh completion
