### PR TITLE
Dynamically update the greeter text

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -110,6 +110,7 @@ int internal_line_source = 0;
 float refresh_rate = 1.0;
 
 bool show_clock = false;
+bool update_greeter = false;
 bool slideshow_enabled = false;
 bool always_show_clock = false;
 bool show_indicator = false;
@@ -198,6 +199,7 @@ char* lock_failed_text = "lock failed!";
 int   keylayout_mode = -1;
 char* layout_text = NULL;
 char* greeter_text = "";
+char* greeter_cmd = "";
 
 /* opts for blurring */
 bool blur = false;
@@ -1603,6 +1605,7 @@ int main(int argc, char *argv[]) {
         {"indicator", no_argument, NULL, 401},
         {"radius", required_argument, NULL, 402},
         {"ring-width", required_argument, NULL, 403},
+        {"greeter-cmd", required_argument, NULL, 404},
 
         // alignment
         {"time-align", required_argument, NULL, 500},
@@ -1941,6 +1944,10 @@ int main(int argc, char *argv[]) {
                     ring_width = 7.0;
                 }
                 break;
+            case 404:
+                update_greeter = true;
+                greeter_cmd = optarg;
+                break;
 
 			// Alignment stuff
             case 500:
@@ -2014,6 +2021,9 @@ int main(int argc, char *argv[]) {
                 lock_failed_text = optarg;
                 break;
             case 518:
+                if (greeter_cmd) {
+                    errx(EXIT_FAILURE, "i3lock-color: Options greeter-text and greeter-cmd conflict.");
+                }
                 greeter_text = optarg;
                 break;
             case 519:
@@ -2626,7 +2636,7 @@ int main(int argc, char *argv[]) {
      * file descriptor becomes readable). */
     ev_invoke(main_loop, xcb_check, 0);
 
-    if (show_clock || bar_enabled || slideshow_enabled) {
+    if (show_clock || bar_enabled || slideshow_enabled || update_greeter) {
         if (redraw_thread) {
             struct timespec ts;
             double s;
@@ -2658,4 +2668,20 @@ int main(int argc, char *argv[]) {
     xcb_aux_sync(conn);
 
     return 0;
+}
+
+void update_greeter_text() {
+    FILE *fp;
+    static char file_text[128];
+
+    memset(file_text,0,sizeof(file_text));
+
+    DEBUG("greeter_cmd is: [%s]\n", greeter_cmd);
+    if((fp = popen(greeter_cmd, "r")) == NULL)
+        return;
+
+    fread(file_text, sizeof(char), sizeof(file_text), fp);
+    pclose(fp);
+
+    greeter_text = file_text;
 }

--- a/i3lock.h
+++ b/i3lock.h
@@ -15,4 +15,6 @@
          }                                                          \
     } while (0)
 
+void update_greeter_text();
+
 #endif

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -109,6 +109,7 @@ extern int screen_number;
 extern float refresh_rate;
 
 extern bool show_clock;
+extern bool update_greeter;
 extern bool always_show_clock;
 extern bool show_indicator;
 extern int verif_align;
@@ -920,6 +921,9 @@ void render_lock(uint32_t *resolution, xcb_drawable_t drawable) {
     }
 
     if (greeter_text) {
+        if(update_greeter) {
+            update_greeter_text();
+        }
         draw_data.greeter_text.show = true;
         strncpy(draw_data.greeter_text.str, greeter_text, sizeof(draw_data.greeter_text.str) - 1);
         draw_data.greeter_text.size = greeter_size;


### PR DESCRIPTION
Closes #234

## Description

Adds new flag: `--greeter-cmd`, which accepts a command name to execute and set the output as the greeter text.

This new flag conflicts with `--greeter-text` because the output from the command overrides the variable containing the greeter text passed with `--greeter-text`, so they can't be used together.

If the indicator is idle, the greeter gets updated every second, if the user is typing, the greeter gets updated at every key press, this could lead to performance issues?

## Alternative
The function that updates the greeter text executes the expression passed by `--greeter-cmd` this can lead to erratic behavior if the user isn't careful enough, for example if the user passes the i3lock invocation script as the argument it can lead to a fork bomb.

```c
void update_greeter_text() {
    FILE *fp;
    static char file_text[128];

    memset(file_text,0,sizeof(file_text));

    DEBUG("greeter_cmd is: [%s]\n", greeter_cmd);
    if((fp = popen(greeter_cmd, "r")) == NULL)
        return;

    fread(file_text, sizeof(char), sizeof(file_text), fp);
    pclose(fp);

    greeter_text = file_text;
}
``` 

An alternative implementation of this function would be using a temporary file for example `/tmp/i3lock-greeter-text` and  updating the greeter text based on the contents of this file. Maybe this would be a better solution?


### Screenshots/screencaps
In this example I plug the power cord and the battery icon updates:

![dynamic-greeter](https://github.com/Raymo111/i3lock-color/assets/64109770/02721fe0-fa28-4ae5-802f-9ff58695245f)

In the screencap I invoke i3lock with these flags:

```shell
$ i3lock -c 00000000 --wrong-text="" --lock-text="" --lockfailed-text="" \
        --verif-text="" --verif-text="" --noinput-text="" \
        -i $HOME/.cache/wall_dimblur.png \
        -M --pointer default -k \
        --time-str="%H:%M" --time-size=110 \
        --time-font="Segoe UI Variable Static Display:style=Semibold" \
        --time-pos="ix:iy - 142" --time-color="FFFFFFCC" \
        --date-str="%A, %B %d" --date-size=26 \
        --date-font="Segoe UI Variable Static Display:style=Semibold" \
        --date-pos="tx:ty + 35 + 1" --date-color="FFFFFFCC" \
        --bar-indicator --bar-direction 2 --bar-color 00000000 --bar-pos "h" \
        --bar-step 6 --bar-max-height 6 --bar-periodic-step 6 \
        --keyhl-color="736654CC" -e -n \
        --greeter-pos="tx:ty + 70" \
        --greeter-color="FFFFFFCC" --greeter-font="CaskaydiaCove Nerd Font" \
        --greeter-size=20 --greeter-cmd="lockscreen-greeter"
```

Being `lockscreen-greeter` a script which contains:

```shell
#!/bin/sh

battery=$(battery-percentage-nerd-font)
kbmap=$(setxkbmap -query | grep -oP 'layout:\s*\K\w+')

printf "%s 󰇙 󰌌 %s" "$battery" "$kbmap"
``` 

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: no-notes.
