### PR TITLE
use fast filter to prevent performance issues when downscaling image

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -1221,6 +1221,7 @@ void draw_image(uint32_t* root_resolution, cairo_surface_t *img, cairo_t* xcb_ct
     cairo_pattern_t *pattern = cairo_pattern_create_for_surface(img);
     cairo_pattern_set_extend(pattern, bg_type == TILE ? CAIRO_EXTEND_REPEAT : CAIRO_EXTEND_NONE);
     cairo_set_source(xcb_ctx, pattern);
+    cairo_pattern_set_filter(pattern, CAIRO_FILTER_FAST);
 
     double image_width = cairo_image_surface_get_width(img);
     double image_height = cairo_image_surface_get_height(img);


### PR DESCRIPTION
## Description
- cairo is very slow at downscaling images using the default filter. This PR fixes that by setting the CAIRO_FILTER_FAST filter.