### PR TITLE
Ensure that input focus is returned to correct window when i3lock quits

### DIFF
--- a/i3lock.c
+++ b/i3lock.c
@@ -2655,6 +2655,7 @@ int main(int argc, char *argv[]) {
     xcb_ungrab_keyboard(conn, XCB_CURRENT_TIME);
     xcb_destroy_window(conn, win);
     set_focused_window(conn, screen->root, stolen_focus);
+    xcb_set_input_focus(conn, XCB_INPUT_FOCUS_PARENT /* revert_to */, stolen_focus, XCB_CURRENT_TIME);
     xcb_aux_sync(conn);
 
     return 0;


### PR DESCRIPTION
## Description
 - The input focus does not always return to the previously focused window after i3lock-color quits.
 - For example, when the `--composite` option is enabled, the parent window set by `parent_win = composite_reply->overlay_win;` in `xcb.c` can be different from the window from which focus was stolen.
 - If i3-lock fails to grab the pointer and keyboard on its first attempt, the input focus will be set to i3lock and will later revert to the parent window (which may not be the correct window when the `--composite` option is enabled) as shown below (comments removed)
``` 
    auth_state = STATE_AUTH_LOCK;
    if (!grab_pointer_and_keyboard(conn, screen, cursor, 1000)) {
        DEBUG("stole focus from X11 window 0x%08x\n", stolen_focus);

        xcb_set_input_focus(conn, XCB_INPUT_FOCUS_PARENT /* revert_to */, win, XCB_CURRENT_TIME);
        ...
    }
```
 - Incorrectly reverting the input focus can cause user input in DE/WMs to seem "frozen" since keyboard input may not appear to work (although the mouse may work).
 - Adding `xcb_set_input_focus(conn, XCB_INPUT_FOCUS_PARENT /* revert_to */, stolen_focus, XCB_CURRENT_TIME);` to the end of `main(...)`, ensures that focus returns to the correct window `stolen_focus`.