### PR TITLE
fixed typo error README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ i3lock is a simple screen locker like slock. After starting it, you will see a w
 Many little improvements have been made to i3lock over time:
 
 - i3lock forks, so you can combine it with an alias to suspend to RAM (run "i3lock && echo mem > /sys/power/state" to get a locked screen after waking up your computer from suspend to RAM)
-- You can specify either a background color or an image (JPG or PNG), which will be displayed while your screen is locked. Note that i3lock is not an image manipulation software. If you need to resize the image to fill the screen, you can use something like ImageMagick combined wih `xdpyinfo`:
+- You can specify either a background color or an image (JPG or PNG), which will be displayed while your screen is locked. Note that i3lock is not an image manipulation software. If you need to resize the image to fill the screen, you can use something like ImageMagick combined with `xdpyinfo`:
 	```bash
 	convert image.jpg -resize $(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/') RGB:- | i3lock --raw $(xdpyinfo | grep dimensions | sed -r 's/^[^0-9]*([0-9]+x[0-9]+).*$/\1/'):rgb --image /dev/stdin
 	```


### PR DESCRIPTION
This pull request fixes a small typo in the documentation.

    "wih" → "with" in the sentence mentioning ImageMagick and xdpyinfo.
