### PR TITLE
adding libgif-dev as debian dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The following dependencies will need to be installed for a successful build, dep
 ### Debian
 Run this command to install all dependencies:
 ```
-sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util0-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
+sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util0-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev libgif-dev
 ```
 If you still see missing packages during build after installing all of these dependencies, try following the steps [here](https://github.com/Raymo111/i3lock-color/issues/211#issuecomment-809891727).
 


### PR DESCRIPTION
## Description
 - I have installing all dependencies as described in the README and still got this error: configure: `error: cannot find the gif_lib.h header, which i3lock requires`. Installing this package fixed the problem: `ibgif-dev`. I’ve updated the README to include this dependency to prevent future confusion.


