### PR TITLE
added libgif-dev as ubuntu dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ sudo dnf install -y autoconf automake cairo-devel fontconfig gcc libev-devel lib
 ### Ubuntu 18/20.04 LTS
 Run this command to install all dependencies:
 ```
-sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev
+sudo apt install autoconf gcc make pkg-config libpam0g-dev libcairo2-dev libfontconfig1-dev libxcb-composite0-dev libev-dev libx11-xcb-dev libxcb-xkb-dev libxcb-xinerama0-dev libxcb-randr0-dev libxcb-image0-dev libxcb-util-dev libxcb-xrm-dev libxkbcommon-dev libxkbcommon-x11-dev libjpeg-dev libgif-dev
 ```
 
 ## Building i3lock-color


### PR DESCRIPTION
<!--
(Opional) What i3lock-color issue does this PR address? (for example, #1234)
-->
Very similar to PR #307, just for the Ubuntu section.
Also addresses (already closed) issue #308.

## Description
 - Adds `libgif-dev` as an Ubuntu dependency in the README

### Screenshots/screencaps
<!--
Include screenshots or gifs if relevant.
-->
```
...
checking for gif_lib.h... no
configure: error: in `.../i3lock-color/build':
configure: error: cannot find the gif_lib.h header, which i3lock requires
See `config.log' for more details
+ make
make: *** No targets specified and no makefile found.  Stop.
make: *** No rule to make target 'install'.  Stop.
i3lock-color installed. The binary and manpage listing are `i3lock'.
The license can be found at /usr/share/licenses/i3lock-color/LICENSE
GitHub repo: https://github.com/Raymo111/i3lock-color
Discord server: https://discord.gg/FzVPghyDt2
```


## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: no-notes
