### PR TITLE
cava style bar indicator

### DIFF
--- a/i3lock.1
+++ b/i3lock.1
@@ -485,6 +485,14 @@ Sets the number of minibars to draw on each screen.
 The total width of the bar. Can be an expression.
 
 .TP
+.B \-\-bar\-cava\-style
+Special bar indicator style mimicking an audio visualizer.
+
+.TP
+.B \-\-bar\-cava\-decay
+Sets the relative interval between bar heights.
+
+.TP
 .B \-\-redraw\-thread
 Starts a separate thread for redrawing the screen. Potentially worse from a
 security standpoint, but makes the bar indicator still do its usual periodic

--- a/i3lock.c
+++ b/i3lock.c
@@ -322,6 +322,7 @@ char bar_y_expr[32] = ""; // empty string on y means use x as offset based on or
 char bar_width_expr[32] = ""; // empty string means full width based on bar orientation
 bool bar_bidirectional = false;
 bool bar_reversed = false;
+bool bar_cava_style = false;
 
 enum IMAGE_FORMAT {
     IMAGE_FORMAT_UNKNOWN,
@@ -1907,6 +1908,7 @@ int main(int argc, char *argv[]) {
         {"bar-pos", required_argument, NULL, 709},
         {"bar-count", required_argument, NULL, 710},
         {"bar-total-width", required_argument, NULL, 711},
+        {"bar-cava-style", no_argument, NULL, 712},
 
         // misc.
         {"redraw-thread", no_argument, NULL, 900},
@@ -2570,6 +2572,9 @@ int main(int argc, char *argv[]) {
                 if (sscanf(arg, "%31s", bar_width_expr) != 1) {
                     errx(1, "missing argument for bar-total-width\n");
                 }
+                break;
+            case 712:
+                bar_cava_style = true;
                 break;
 
 			// Misc

--- a/i3lock.c
+++ b/i3lock.c
@@ -313,6 +313,7 @@ double bar_step = 15;
 double bar_base_height = 25;
 double bar_periodic_step = 15;
 double max_bar_height = 25;
+double bar_cava_decay = 0.5;
 int bar_count = 10;
 int bar_orientation = BAR_FLAT;
 
@@ -1909,6 +1910,7 @@ int main(int argc, char *argv[]) {
         {"bar-count", required_argument, NULL, 710},
         {"bar-total-width", required_argument, NULL, 711},
         {"bar-cava-style", no_argument, NULL, 712},
+        {"bar-cava-decay", required_argument, NULL, 713},
 
         // misc.
         {"redraw-thread", no_argument, NULL, 900},
@@ -2575,6 +2577,11 @@ int main(int argc, char *argv[]) {
                 break;
             case 712:
                 bar_cava_style = true;
+                break;
+            case 713:
+                bar_cava_decay = strtod(optarg, NULL);
+                if (!bar_cava_decay)
+                    bar_cava_decay = 0.5;
                 break;
 
 			// Misc

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -237,6 +237,7 @@ extern double bar_base_height;
 extern double bar_periodic_step;
 extern double max_bar_height;
 extern double bar_position;
+extern double bar_cava_decay;
 extern int bar_count;
 extern int bar_orientation;
 
@@ -738,7 +739,7 @@ static void draw_elements(cairo_t *const ctx, DrawData const *const draw_data) {
                 }
                 int high_ind = (index + i) % bar_count;
                 if (bar_cava_style)
-                    tmp_height = ((double)max_bar_height) * exp(-(0.5 * i));
+                    tmp_height = ((double)max_bar_height) * exp(-(bar_cava_decay * i));
                 else
                     tmp_height = max_bar_height - (bar_step * i);
                 if (tmp_height < 0)

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -730,13 +730,17 @@ static void draw_elements(cairo_t *const ctx, DrawData const *const draw_data) {
             // maybe see about doing ((double) rand() / RAND_MAX) * bar_count
             int index = rand() % bar_count;
             bar_heights[index] = max_bar_height;
+            int tmp_height = max_bar_height;
             for (int i = 0; i < ((max_bar_height / bar_step) + 1); ++i) {
                 int low_ind = index - i;
                 while (low_ind < 0) {
                     low_ind += bar_count;
                 }
                 int high_ind = (index + i) % bar_count;
-                int tmp_height = max_bar_height - (bar_step * i);
+                if (bar_cava_style)
+                    tmp_height = ((double)max_bar_height) * exp(-(0.5 * i));
+                else
+                    tmp_height = max_bar_height - (bar_step * i);
                 if (tmp_height < 0)
                     tmp_height = 0;
                 if (bar_heights[low_ind] < tmp_height)

--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -246,6 +246,7 @@ extern char bar_y_expr[32];
 extern char bar_width_expr[32];
 extern bool bar_bidirectional;
 extern bool bar_reversed;
+extern bool bar_cava_style;
 
 static cairo_font_face_t *font_faces[6] = {
     NULL,


### PR DESCRIPTION
## Adds an option to make the bar indicator look like an audio visualizer
 - 2 new flags : `--bar-cava-style` and `--bar-cava-delay [delay]`. The latter defaults to 0.5.

### Screenshots/screencaps
<!--
Include screenshots or gifs if relevant.
-->
![output](https://github.com/user-attachments/assets/889bb602-d211-4784-864b-d0988edd1d50)

## Release notes
<!--
What to include in the notes section of an upcoming release that describes this PR.
If the PR doesn't to be mentioned in the release notes, put "Notes: no-notes".
-->
Notes: no-notes
